### PR TITLE
feat: implement get_user_info Tauri command and resolve frontend TODO

### DIFF
--- a/desktop/wkyt/src-tauri/src/google_auth.rs
+++ b/desktop/wkyt/src-tauri/src/google_auth.rs
@@ -36,6 +36,18 @@ pub fn exchange_code_for_token(code: String) -> String {
     format!("mock-token-for-{}", code)
 }
 
+#[tauri::command]
+pub fn get_user_info(token: String) -> GoogleUser {
+    // In a real app, verify token and fetch user info
+    // For now, return the mock user expected by the frontend
+    println!("Getting user info for token: {}", token);
+    GoogleUser {
+        email: "test@example.com".to_string(),
+        name: "Test User".to_string(),
+        picture: None,
+    }
+}
+
 pub fn initiate_auth(window: &Window) {
     // This is where we would trigger the OIDC flow
     // For now, we just emit a mock success event

--- a/desktop/wkyt/src-tauri/src/lib.rs
+++ b/desktop/wkyt/src-tauri/src/lib.rs
@@ -67,7 +67,8 @@ pub fn run() {
             greet,
             google_auth::start_oauth,
             google_auth::logout,
-            google_auth::exchange_code_for_token
+            google_auth::exchange_code_for_token,
+            google_auth::get_user_info
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/wkyt/src/routes/+page.svelte
+++ b/desktop/wkyt/src/routes/+page.svelte
@@ -12,7 +12,13 @@
 
   import { listen } from "@tauri-apps/api/event";
 
-  let user = $state(null);
+  interface User {
+    name: string;
+    email: string;
+    picture?: string;
+  }
+
+  let user = $state<User | null>(null);
 
   async function loginWithGoogle() {
     await invoke("start_oauth", { state: "some-random-state" });
@@ -27,8 +33,7 @@
     console.log("got oauth-code", event.payload);
     const token = await invoke("exchange_code_for_token", { code: event.payload });
     console.log("got token", token);
-    // TODO: get user info from token
-    user = { name: "Test User", email: "test@example.com" };
+    user = await invoke("get_user_info", { token });
   });
 </script>
 


### PR DESCRIPTION
This PR addresses the "TODO: Get User Info From Token" issue in `desktop/wkyt/src/routes/+page.svelte`.

Changes:
- **Backend**: Implemented `get_user_info` Tauri command in `src-tauri/src/google_auth.rs` which returns a `GoogleUser` struct. Currently, it returns mock data consistent with the existing mock authentication flow.
- **Backend**: Registered the new command in `src-tauri/src/lib.rs`.
- **Frontend**: Updated `src/routes/+page.svelte` to call `invoke("get_user_info", { token })` after token exchange.
- **Frontend**: Added TypeScript interface `User` to `+page.svelte` to resolve type errors with Svelte 5 runes.

Verification:
- Ran `npm run check` to verify frontend TypeScript compilation.
- Verified Rust code structure and command registration.
- Confirmed `GoogleUser` struct implements `Serialize`.


---
*PR created automatically by Jules for task [2604115078517565395](https://jules.google.com/task/2604115078517565395) started by @redog*