### PR TITLE
⚡ Optimize blocking DB operation with spawn_blocking

### DIFF
--- a/desktop/wkyt/src-tauri/src/lib.rs
+++ b/desktop/wkyt/src-tauri/src/lib.rs
@@ -50,10 +50,17 @@ pub fn run() {
                         println!("Ingested {} items from mock connector.", items.len());
 
                         // Save items to DuckDB
-                        if let Err(e) = storage.save_items(&items) {
-                            eprintln!("Failed to save items to DB: {}", e);
-                        } else {
-                            println!("Saved {} items to DB.", items.len());
+                        let storage_clone = Arc::clone(&storage);
+                        let items_len = items.len();
+                        let save_result = tauri::async_runtime::spawn_blocking(move || {
+                            storage_clone.save_items(&items)
+                        })
+                        .await;
+
+                        match save_result {
+                            Ok(Ok(_)) => println!("Saved {} items to DB.", items_len),
+                            Ok(Err(e)) => eprintln!("Failed to save items to DB: {}", e),
+                            Err(e) => eprintln!("Failed to join blocking task: {}", e),
                         }
                     }
                     Err(e) => eprintln!("Connector init failed: {}", e),


### PR DESCRIPTION
The patch offloads a synchronous database save operation to a background thread pool using `spawn_blocking`. This ensures that the async executor threads remain available for other tasks, improving the responsiveness of the application, especially during large data ingestions. Benchmarking in the current environment was impractical due to network/dependency restrictions, but the change follows established performance best practices for Rust async applications.

---
*PR created automatically by Jules for task [11647151747177162964](https://jules.google.com/task/11647151747177162964) started by @redog*