### PR TITLE
🔒 Fix hardcoded OAuth state parameter

### DIFF
--- a/desktop/wkyt/src-tauri/src/google_auth.rs
+++ b/desktop/wkyt/src-tauri/src/google_auth.rs
@@ -8,6 +8,12 @@ pub struct GoogleUser {
     pub picture: Option<String>,
 }
 
+#[derive(Debug, Serialize, Clone)]
+pub struct OAuthCodePayload {
+    pub code: String,
+    pub state: String,
+}
+
 // Basic auth state holder (placeholder for real OAuth flow)
 pub struct AuthState {
     pub current_user: Option<GoogleUser>,
@@ -20,18 +26,24 @@ impl AuthState {
 }
 
 #[tauri::command]
-pub fn start_oauth(window: Window, _state: String) -> Result<(), String> {
+pub fn start_oauth(window: Window, state: String) -> Result<(), String> {
     #[cfg(debug_assertions)]
     {
         // This is where we would trigger the OIDC flow
         // For now, we just emit a mock oauth-code event
-        let _ = window.emit("oauth-code", "mock-code-123");
+        let _ = window.emit(
+            "oauth-code",
+            OAuthCodePayload {
+                code: "mock-code-123".to_string(),
+                state,
+            },
+        );
         Ok(())
     }
     #[cfg(not(debug_assertions))]
     {
         let _ = window;
-        let _ = _state;
+        let _ = state;
         // In production, real OAuth flow must be implemented.
         Err("OAuth flow is not implemented for production builds yet.".to_string())
     }

--- a/desktop/wkyt/src/routes/+page.svelte
+++ b/desktop/wkyt/src/routes/+page.svelte
@@ -19,10 +19,12 @@
   }
 
   let user = $state<User | null>(null);
+  let oauthState = "";
 
   async function loginWithGoogle() {
     try {
-      await invoke("start_oauth", { state: "some-random-state" });
+      oauthState = crypto.randomUUID();
+      await invoke("start_oauth", { state: oauthState });
     } catch (error) {
       console.error("Failed to start OAuth:", error);
       alert("Failed to start authentication flow. Please try again later.");
@@ -41,8 +43,16 @@
 
   listen("oauth-code", async (event) => {
     console.log("got oauth-code", event.payload);
+    const { code, state } = event.payload as { code: string; state: string };
+
+    if (state !== oauthState) {
+      console.error("OAuth state mismatch!");
+      alert("Authentication failed: invalid state.");
+      return;
+    }
+
     try {
-      const token = await invoke<string>("exchange_code_for_token", { code: event.payload });
+      const token = await invoke<string>("exchange_code_for_token", { code });
       console.log("got token", token);
       user = await invoke<User>("get_user_info", { token });
     } catch (error) {


### PR DESCRIPTION
This PR addresses a security vulnerability where a hardcoded state parameter was used in the Google OAuth flow.

### 🎯 What
- Replaced the hardcoded state "some-random-state" with a dynamically generated `crypto.randomUUID()`.
- Updated the Tauri backend to include the received state in the `oauth-code` event payload.
- Added verification logic in the frontend to ensure the returned state matches the generated one.

### ⚠️ Risk
Leaving the OAuth state hardcoded makes the authentication flow susceptible to Cross-Site Request Forgery (CSRF) attacks. An attacker could potentially initiate an authentication flow and trick a user into completing it, leading to account linkage or other unauthorized actions.

### 🛡️ Solution
By generating a unique, cryptographically secure state for each authentication request and verifying it when the authorization code is returned, we ensure that the authentication response corresponds to a request initiated by the same user agent, effectively blocking CSRF attempts.

---
*PR created automatically by Jules for task [8627273229073801173](https://jules.google.com/task/8627273229073801173) started by @redog*