### PR TITLE
feat: M2 crypto core — KEK/DEK key service, recovery wrappers, sqlcip…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +754,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +789,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -819,6 +864,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -840,7 +895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -853,7 +908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -925,6 +980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1010,6 +1066,16 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -1196,7 +1262,7 @@ dependencies = [
  "comfy-table",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.10.0",
  "libduckdb-sys",
  "num-integer",
  "rust_decimal",
@@ -1851,6 +1917,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1863,6 +1938,15 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "hashlink"
@@ -2187,6 +2271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,6 +2441,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2603,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2969,6 +3089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,6 +3104,28 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3199,6 +3347,17 @@ dependencies = [
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3767,6 +3926,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3942,6 +4115,42 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -4400,7 +4609,7 @@ checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -5211,6 +5420,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -6180,6 +6399,16 @@ version = "0.1.0"
 [[package]]
 name = "wkyt-vault"
 version = "0.1.0"
+dependencies = [
+ "chacha20poly1305",
+ "keyring",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "zeroize",
+]
 
 [[package]]
 name = "writeable"
@@ -6401,6 +6630,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/wkyt-vault/Cargo.toml
+++ b/crates/wkyt-vault/Cargo.toml
@@ -1,10 +1,31 @@
 [package]
 name = "wkyt-vault"
-description = "Encrypted SQLite vault: schema, atomic batch-apply, key service (lands in M2)"
+description = "Encrypted SQLite vault: KEK/DEK key service, recovery wrappers, sqlcipher init (D1/D10/D12)"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 
-# Intentionally empty until M2: stub crates carry no dependencies
-# (Spec: every dependency must justify its existence).
 [dependencies]
+# Encrypted SQLite (D1/D10). bundled-sqlcipher-vendored-openssl compiles
+# sqlcipher AND its OpenSSL from source: no system library needed, so a
+# clean machine still builds with only rustup + npm (Spec DoD #1).
+rusqlite = { version = "0.31", features = ["bundled-sqlcipher-vendored-openssl"] }
+# OS keychain for the KEK (D2/D12): Secret Service on Linux, Keychain on
+# macOS, Credential Manager on Windows. The backends are explicit features.
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+# AEAD for wrapping the DEK (D12). XChaCha20-Poly1305: misuse-resistant
+# 24-byte random nonces, authenticated (tamper-evident) ciphertext,
+# pure-Rust RustCrypto implementation.
+chacha20poly1305 = "0.10"
+# Best-effort erasure of key material on drop (D12 memory hygiene);
+# Zeroizing<T> wrappers around every buffer that holds a key.
+zeroize = "1"
+# Error types for the key service and vault (no key material in messages).
+thiserror = { workspace = true }
+# Wrapped-DEK blob file format (versioned JSON envelope, D12).
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+# Isolated per-test data dirs so key/vault tests can't touch real state.
+tempfile = "3"

--- a/crates/wkyt-vault/src/hexfmt.rs
+++ b/crates/wkyt-vault/src/hexfmt.rs
@@ -1,0 +1,99 @@
+//! Minimal hex helpers for key blobs and the recovery-key display format.
+//! Hand-rolled (~30 lines) rather than a crate dependency; covered by
+//! round-trip tests below. Not constant-time — never used to compare
+//! secrets, only to encode/decode them.
+
+/// Lowercase hex encoding.
+pub fn encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+        out.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
+    }
+    out
+}
+
+/// Strict decode: even length, hex digits only.
+pub fn decode(s: &str) -> Option<Vec<u8>> {
+    if s.len() % 2 != 0 {
+        return None;
+    }
+    s.as_bytes()
+        .chunks(2)
+        .map(|pair| {
+            let hi = (pair[0] as char).to_digit(16)?;
+            let lo = (pair[1] as char).to_digit(16)?;
+            Some(((hi << 4) | lo) as u8)
+        })
+        .collect()
+}
+
+/// Decode exactly 32 bytes of user-typed hex, tolerating the separators a
+/// human will plausibly paste back: dashes, spaces, newlines, mixed case.
+/// Anything else (or a wrong digit count) is rejected.
+pub fn decode_key32_lenient(input: &str) -> Option<[u8; 32]> {
+    let mut cleaned = String::with_capacity(64);
+    for c in input.chars() {
+        match c {
+            '-' | ' ' | '\t' | '\r' | '\n' => continue,
+            c if c.is_ascii_hexdigit() => cleaned.push(c.to_ascii_lowercase()),
+            _ => return None,
+        }
+    }
+    if cleaned.len() != 64 {
+        return None;
+    }
+    let v = decode(&cleaned)?;
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&v);
+    Some(out)
+}
+
+/// Uppercase, dash-grouped display for the recovery ceremony:
+/// `D2AB-12F0-…` (16 groups of 4). Input must be 64 hex chars.
+pub fn group_for_display(hex64: &str) -> String {
+    debug_assert_eq!(hex64.len(), 64);
+    hex64
+        .as_bytes()
+        .chunks(4)
+        .map(|c| std::str::from_utf8(c).unwrap().to_ascii_uppercase())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_all_byte_values() {
+        let bytes: Vec<u8> = (0..=255).collect();
+        assert_eq!(decode(&encode(&bytes)).unwrap(), bytes);
+    }
+
+    #[test]
+    fn strict_decode_rejects_garbage() {
+        assert!(decode("abc").is_none()); // odd length
+        assert!(decode("zz").is_none()); // not hex
+    }
+
+    #[test]
+    fn lenient_decode_accepts_human_formats() {
+        let key = [0xAB; 32];
+        let hex = encode(&key);
+        let displayed = group_for_display(&hex);
+        assert_eq!(decode_key32_lenient(&displayed).unwrap(), key);
+        assert_eq!(decode_key32_lenient(&hex).unwrap(), key);
+        assert_eq!(
+            decode_key32_lenient(&format!(" {} \n", displayed.to_lowercase())).unwrap(),
+            key
+        );
+    }
+
+    #[test]
+    fn lenient_decode_rejects_wrong_length_and_alphabet() {
+        assert!(decode_key32_lenient("abcd").is_none());
+        assert!(decode_key32_lenient(&"g".repeat(64)).is_none());
+        assert!(decode_key32_lenient(&"a".repeat(66)).is_none());
+    }
+}

--- a/crates/wkyt-vault/src/keys.rs
+++ b/crates/wkyt-vault/src/keys.rs
@@ -1,0 +1,519 @@
+//! KEK/DEK key service (D12) and recovery wrappers (D8, as amended).
+//!
+//! Key hierarchy:
+//!
+//! ```text
+//!   OS keychain ──holds──> KEK ──unwraps──> ┐
+//!                                            ├─> DEK ──PRAGMA key──> sqlcipher
+//!   user (paper) ─holds──> recovery key ───> ┘
+//! ```
+//!
+//! The DEK is wrapped twice with XChaCha20-Poly1305 into two blob files on
+//! disk: `dek.keychain.json` (wrapped by the keychain KEK; the silent
+//! cold-start path) and `dek.recovery.json` (wrapped by the user-held
+//! recovery key; the keychain-loss path). The AEAD's associated data binds
+//! each blob to its purpose and format version, so a recovery blob cannot
+//! be swapped in for a keychain blob (or vice versa) without detection.
+//!
+//! Memory rules: every buffer that ever holds key material is
+//! `Zeroizing`; `Dek`/`RecoveryKey` redact their `Debug` output; no error
+//! variant carries key bytes. Honest limits (D12): the keychain IPC and
+//! the OS keychain daemon hold copies we cannot zeroize, and the DEK
+//! necessarily lives in sqlcipher's memory while the vault is open —
+//! `Vault::open` enables `cipher_memory_security` to make sqlcipher lock
+//! and wipe its own crypto buffers.
+
+use crate::hexfmt;
+use chacha20poly1305::{
+    aead::{Aead, AeadCore, KeyInit, OsRng, Payload},
+    XChaCha20Poly1305, XNonce,
+};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use zeroize::Zeroizing;
+
+pub const KEY_LEN: usize = 32;
+const BLOB_VERSION: u32 = 1;
+const XNONCE_LEN: usize = 24;
+
+const KEYCHAIN_BLOB: &str = "dek.keychain.json";
+const RECOVERY_BLOB: &str = "dek.recovery.json";
+const KEYRING_USER: &str = "vault-kek";
+
+/// The data encryption key: what sqlcipher receives. Exists unwrapped only
+/// in process memory; zeroized on drop. Bytes are deliberately reachable
+/// only inside this crate (`Vault::open` needs them; nothing else does).
+pub struct Dek(Zeroizing<[u8; KEY_LEN]>);
+
+impl Dek {
+    fn generate() -> Self {
+        Dek(Zeroizing::new(XChaCha20Poly1305::generate_key(&mut OsRng).into()))
+    }
+
+    pub(crate) fn bytes(&self) -> &[u8; KEY_LEN] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Dek {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Dek(<redacted>)")
+    }
+}
+
+/// The user-held recovery key (the second KEK). Displayed exactly once at
+/// the D8 ceremony; zeroized on drop; Debug redacted.
+pub struct RecoveryKey(Zeroizing<[u8; KEY_LEN]>);
+
+impl RecoveryKey {
+    fn generate() -> Self {
+        RecoveryKey(Zeroizing::new(XChaCha20Poly1305::generate_key(&mut OsRng).into()))
+    }
+
+    /// Parse user input back into a key, tolerating display formatting.
+    pub fn parse(input: &str) -> Result<Self, KeyError> {
+        hexfmt::decode_key32_lenient(input)
+            .map(|k| RecoveryKey(Zeroizing::new(k)))
+            .ok_or(KeyError::MalformedRecoveryKey)
+    }
+
+    /// The dash-grouped string shown during the ceremony. Returned inside
+    /// `Zeroizing` so the caller's copy is erased on drop too; the UI layer
+    /// owns whatever copies the clipboard/renderer make (documented UX
+    /// trade-off — the key must reach the user somehow).
+    pub fn display(&self) -> Zeroizing<String> {
+        let hex = Zeroizing::new(hexfmt::encode(&*self.0));
+        Zeroizing::new(hexfmt::group_for_display(&hex))
+    }
+}
+
+impl std::fmt::Debug for RecoveryKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("RecoveryKey(<redacted>)")
+    }
+}
+
+/// No key bytes in any variant, ever: errors get logged and shown in UI.
+#[derive(Debug, thiserror::Error)]
+pub enum KeyError {
+    #[error("keychain unavailable or failed: {0}")]
+    Keychain(String),
+    #[error("no KEK in the OS keychain (keychain lost or never provisioned)")]
+    KekMissing,
+    #[error("key blob {0:?} is missing")]
+    BlobMissing(PathBuf),
+    #[error("key blob failed authentication (wrong key, tampered, or corrupt)")]
+    IntegrityFailure,
+    #[error("recovery key is not in the expected format (64 hex digits)")]
+    MalformedRecoveryKey,
+    #[error("unsupported key blob version {0}")]
+    UnsupportedBlobVersion(u32),
+    #[error("key state is inconsistent: {0}")]
+    Inconsistent(&'static str),
+    #[error("io error on key blob: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("key blob is not valid JSON: {0}")]
+    Format(#[from] serde_json::Error),
+}
+
+/// What the caller should do next, decided before touching the DEK.
+#[derive(Debug, PartialEq, Eq)]
+pub enum KeyState {
+    /// Nothing provisioned: run `provision()` and the recovery ceremony.
+    FirstRun,
+    /// Wrapped DEK + KEK present: `unlock()`.
+    Ready,
+    /// Wrapped DEK present but the keychain entry is gone (OS reinstall,
+    /// keyring wipe): prompt for the recovery key, then `recover()`.
+    KeychainLost,
+    /// Data exists but key material does not (or only partially). Nothing
+    /// can be decrypted without the recovery blob; surface to the operator
+    /// rather than guessing.
+    Inconsistent(&'static str),
+}
+
+/// Where the keychain KEK lives. Production uses [`KeyringStore`]; tests
+/// use [`MemoryKekStore`]; D2's headless-Linux passphrase fallback will be
+/// a third implementation (M6).
+pub trait KekStore {
+    fn get(&self) -> Result<Option<Zeroizing<[u8; KEY_LEN]>>, KeyError>;
+    fn set(&self, kek: &[u8; KEY_LEN]) -> Result<(), KeyError>;
+    fn delete(&self) -> Result<(), KeyError>;
+}
+
+/// OS keychain via the `keyring` crate (D2). The KEK is stored hex-encoded
+/// (keychains store strings). Note: the string crosses the Secret-Service
+/// D-Bus boundary / platform IPC — copies beyond that point are the OS's.
+pub struct KeyringStore {
+    service: String,
+}
+
+impl KeyringStore {
+    pub fn new(service: impl Into<String>) -> Self {
+        Self { service: service.into() }
+    }
+
+    fn entry(&self) -> Result<keyring::Entry, KeyError> {
+        keyring::Entry::new(&self.service, KEYRING_USER)
+            .map_err(|e| KeyError::Keychain(e.to_string()))
+    }
+}
+
+impl KekStore for KeyringStore {
+    fn get(&self) -> Result<Option<Zeroizing<[u8; KEY_LEN]>>, KeyError> {
+        match self.entry()?.get_password() {
+            Ok(hex) => {
+                let hex = Zeroizing::new(hex);
+                let kek = hexfmt::decode_key32_lenient(&hex)
+                    .ok_or(KeyError::Inconsistent("keychain entry is not a 256-bit key"))?;
+                Ok(Some(Zeroizing::new(kek)))
+            }
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(KeyError::Keychain(e.to_string())),
+        }
+    }
+
+    fn set(&self, kek: &[u8; KEY_LEN]) -> Result<(), KeyError> {
+        let hex = Zeroizing::new(hexfmt::encode(kek));
+        self.entry()?
+            .set_password(&hex)
+            .map_err(|e| KeyError::Keychain(e.to_string()))
+    }
+
+    fn delete(&self) -> Result<(), KeyError> {
+        match self.entry()?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(e) => Err(KeyError::Keychain(e.to_string())),
+        }
+    }
+}
+
+/// In-memory KEK store for tests and development. Never persists.
+#[derive(Default)]
+pub struct MemoryKekStore(Mutex<Option<Zeroizing<[u8; KEY_LEN]>>>);
+
+impl KekStore for MemoryKekStore {
+    fn get(&self) -> Result<Option<Zeroizing<[u8; KEY_LEN]>>, KeyError> {
+        Ok(self.0.lock().unwrap().clone())
+    }
+    fn set(&self, kek: &[u8; KEY_LEN]) -> Result<(), KeyError> {
+        *self.0.lock().unwrap() = Some(Zeroizing::new(*kek));
+        Ok(())
+    }
+    fn delete(&self) -> Result<(), KeyError> {
+        *self.0.lock().unwrap() = None;
+        Ok(())
+    }
+}
+
+/// On-disk envelope for a wrapped DEK. Binary fields are hex; the AEAD tag
+/// is inside `ct`. `version` and `purpose` are ALSO bound into the AEAD's
+/// associated data — editing them here breaks authentication, so the JSON
+/// is self-describing but not attacker-malleable.
+#[derive(Serialize, Deserialize)]
+struct BlobFile {
+    version: u32,
+    purpose: String, // "keychain" | "recovery"
+    nonce: String,   // 24-byte XChaCha nonce, hex
+    ct: String,      // ciphertext || Poly1305 tag, hex
+}
+
+fn aad_for(purpose: &str) -> Vec<u8> {
+    format!("wkyt-dek-blob:v{BLOB_VERSION}:{purpose}").into_bytes()
+}
+
+fn wrap(dek: &Dek, kek: &[u8; KEY_LEN], purpose: &str) -> BlobFile {
+    let cipher = XChaCha20Poly1305::new(kek.into());
+    let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+    let ct = cipher
+        .encrypt(&nonce, Payload { msg: dek.bytes(), aad: &aad_for(purpose) })
+        .expect("XChaCha20-Poly1305 encryption is infallible for 32-byte input");
+    BlobFile {
+        version: BLOB_VERSION,
+        purpose: purpose.to_string(),
+        nonce: hexfmt::encode(&nonce),
+        ct: hexfmt::encode(&ct),
+    }
+}
+
+fn unwrap(blob: &BlobFile, kek: &[u8; KEY_LEN], purpose: &str) -> Result<Dek, KeyError> {
+    if blob.version != BLOB_VERSION {
+        return Err(KeyError::UnsupportedBlobVersion(blob.version));
+    }
+    let nonce_bytes = hexfmt::decode(&blob.nonce).ok_or(KeyError::IntegrityFailure)?;
+    let ct = hexfmt::decode(&blob.ct).ok_or(KeyError::IntegrityFailure)?;
+    if nonce_bytes.len() != XNONCE_LEN {
+        return Err(KeyError::IntegrityFailure);
+    }
+    let cipher = XChaCha20Poly1305::new(kek.into());
+    // Deliberately opaque on failure: wrong key, bit-flip, and
+    // purpose-swap (AAD mismatch) are indistinguishable to a caller.
+    let pt = Zeroizing::new(
+        cipher
+            .decrypt(
+                XNonce::from_slice(&nonce_bytes),
+                Payload { msg: &ct, aad: &aad_for(purpose) },
+            )
+            .map_err(|_| KeyError::IntegrityFailure)?,
+    );
+    if pt.len() != KEY_LEN {
+        return Err(KeyError::IntegrityFailure);
+    }
+    let mut dek = Zeroizing::new([0u8; KEY_LEN]);
+    dek.copy_from_slice(&pt);
+    Ok(Dek(dek))
+}
+
+pub struct KeyService<S: KekStore> {
+    store: S,
+    keychain_blob: PathBuf,
+    recovery_blob: PathBuf,
+}
+
+impl<S: KekStore> KeyService<S> {
+    pub fn new(store: S, data_dir: &Path) -> Self {
+        Self {
+            store,
+            keychain_blob: data_dir.join(KEYCHAIN_BLOB),
+            recovery_blob: data_dir.join(RECOVERY_BLOB),
+        }
+    }
+
+    /// Decide the cold-start path. `db_exists` is the caller's check on the
+    /// vault file (the key service deliberately doesn't know the DB path).
+    pub fn state(&self, db_exists: bool) -> Result<KeyState, KeyError> {
+        let kc = self.keychain_blob.exists();
+        let rc = self.recovery_blob.exists();
+        let kek = self.store.get()?.is_some();
+
+        Ok(match (db_exists, kc, rc, kek) {
+            // Fresh install. A keychain blob is written last during
+            // provisioning, so its absence with no DB means any other
+            // debris (orphan KEK, lone recovery blob from an interrupted
+            // provision) is safely overwritten by re-provisioning.
+            (false, false, _, _) => KeyState::FirstRun,
+            (_, true, _, true) => KeyState::Ready,
+            (_, true, true, false) => KeyState::KeychainLost,
+            (_, true, false, false) => {
+                KeyState::Inconsistent("KEK lost and no recovery blob exists")
+            }
+            (true, false, true, _) => KeyState::KeychainLost,
+            (true, false, false, _) => {
+                KeyState::Inconsistent("vault exists but all key material is missing")
+            }
+        })
+    }
+
+    /// First-run provisioning. Generates DEK + both KEKs, persists the
+    /// wrappers, and returns the recovery key for the D8 ceremony — the
+    /// only time it ever exists outside the user's head/paper. The caller
+    /// MUST run the ceremony (display + `verify_recovery`) before writing
+    /// user data.
+    ///
+    /// Write order is crash-safe by construction: KEK → recovery blob →
+    /// keychain blob (last). A crash anywhere before the final write
+    /// leaves `state()` at `FirstRun`, and re-provisioning overwrites the
+    /// debris. Only the final rename makes the provisioning visible.
+    pub fn provision(&self) -> Result<(Dek, RecoveryKey), KeyError> {
+        if self.keychain_blob.exists() {
+            return Err(KeyError::Inconsistent(
+                "already provisioned; refusing to overwrite key material",
+            ));
+        }
+        let dek = Dek::generate();
+        let recovery = RecoveryKey::generate();
+        let kek = Zeroizing::new(<[u8; KEY_LEN]>::from(XChaCha20Poly1305::generate_key(
+            &mut OsRng,
+        )));
+
+        self.store.set(&kek)?;
+        write_blob_atomic(&self.recovery_blob, &wrap(&dek, &recovery.0, "recovery"))?;
+        write_blob_atomic(&self.keychain_blob, &wrap(&dek, &kek, "keychain"))?;
+        Ok((dek, recovery))
+    }
+
+    /// The silent cold-start path: keychain KEK unwraps the DEK.
+    pub fn unlock(&self) -> Result<Dek, KeyError> {
+        let blob = read_blob(&self.keychain_blob)?;
+        let kek = self.store.get()?.ok_or(KeyError::KekMissing)?;
+        unwrap(&blob, &kek, "keychain")
+    }
+
+    /// D8 ceremony verification: proves the user actually saved the key by
+    /// requiring them to re-enter it. Success == the input authenticates
+    /// the recovery blob; nothing is mutated.
+    pub fn verify_recovery(&self, input: &str) -> Result<(), KeyError> {
+        let key = RecoveryKey::parse(input)?;
+        let blob = read_blob(&self.recovery_blob)?;
+        unwrap(&blob, &key.0, "recovery").map(drop)
+    }
+
+    /// Keychain-loss recovery: the recovery key unwraps the DEK, then a
+    /// fresh KEK is generated, stored in the (new) keychain, and the
+    /// keychain blob is re-wrapped. The recovery blob — and the user's
+    /// recovery key — remain valid and unchanged.
+    pub fn recover(&self, input: &str) -> Result<Dek, KeyError> {
+        let key = RecoveryKey::parse(input)?;
+        let blob = read_blob(&self.recovery_blob)?;
+        let dek = unwrap(&blob, &key.0, "recovery")?;
+
+        let kek = Zeroizing::new(<[u8; KEY_LEN]>::from(XChaCha20Poly1305::generate_key(
+            &mut OsRng,
+        )));
+        self.store.set(&kek)?;
+        write_blob_atomic(&self.keychain_blob, &wrap(&dek, &kek, "keychain"))?;
+        Ok(dek)
+    }
+}
+
+fn read_blob(path: &Path) -> Result<BlobFile, KeyError> {
+    if !path.exists() {
+        return Err(KeyError::BlobMissing(path.to_path_buf()));
+    }
+    Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+}
+
+/// Write-to-temp + rename so a crash can never leave a half-written blob,
+/// with 0600 from the moment of creation (D9) on Unix.
+fn write_blob_atomic(path: &Path, blob: &BlobFile) -> Result<(), KeyError> {
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut opts = fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut f = opts.open(&tmp)?;
+        use std::io::Write;
+        f.write_all(serde_json::to_string_pretty(blob)?.as_bytes())?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn svc(dir: &Path) -> KeyService<MemoryKekStore> {
+        KeyService::new(MemoryKekStore::default(), dir)
+    }
+
+    #[test]
+    fn wrap_unwrap_round_trip_and_purpose_binding() {
+        let dek = Dek::generate();
+        let kek = [7u8; KEY_LEN];
+        let blob = wrap(&dek, &kek, "keychain");
+
+        let back = unwrap(&blob, &kek, "keychain").unwrap();
+        assert_eq!(back.bytes(), dek.bytes());
+
+        // Same key, wrong purpose: AAD mismatch must fail closed.
+        assert!(matches!(
+            unwrap(&blob, &kek, "recovery"),
+            Err(KeyError::IntegrityFailure)
+        ));
+        // Wrong key fails identically (no oracle distinguishing the two).
+        assert!(matches!(
+            unwrap(&blob, &[8u8; KEY_LEN], "keychain"),
+            Err(KeyError::IntegrityFailure)
+        ));
+    }
+
+    #[test]
+    fn tampered_ciphertext_is_rejected() {
+        let dek = Dek::generate();
+        let kek = [7u8; KEY_LEN];
+        let mut blob = wrap(&dek, &kek, "keychain");
+        // Flip one nibble of the ciphertext.
+        let mut ct = blob.ct.into_bytes();
+        ct[0] = if ct[0] == b'0' { b'1' } else { b'0' };
+        blob.ct = String::from_utf8(ct).unwrap();
+        assert!(matches!(
+            unwrap(&blob, &kek, "keychain"),
+            Err(KeyError::IntegrityFailure)
+        ));
+    }
+
+    #[test]
+    fn provision_then_unlock_yields_same_dek() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = svc(dir.path());
+        assert_eq!(svc.state(false).unwrap(), KeyState::FirstRun);
+
+        let (dek, recovery) = svc.provision().unwrap();
+        assert_eq!(svc.state(true).unwrap(), KeyState::Ready);
+        assert_eq!(svc.unlock().unwrap().bytes(), dek.bytes());
+
+        // Ceremony verification: displayed form round-trips.
+        svc.verify_recovery(&recovery.display()).unwrap();
+        // And a wrong key does not.
+        assert!(svc.verify_recovery(&"0".repeat(64)).is_err());
+    }
+
+    #[test]
+    fn provision_refuses_to_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = svc(dir.path());
+        svc.provision().unwrap();
+        assert!(matches!(svc.provision(), Err(KeyError::Inconsistent(_))));
+    }
+
+    #[test]
+    fn keychain_loss_is_detected_and_recoverable() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = svc(dir.path());
+        let (dek, recovery) = svc.provision().unwrap();
+
+        svc.store.delete().unwrap(); // simulate keyring wipe / OS reinstall
+        assert_eq!(svc.state(true).unwrap(), KeyState::KeychainLost);
+        assert!(matches!(svc.unlock(), Err(KeyError::KekMissing)));
+
+        let recovered = svc.recover(&recovery.display()).unwrap();
+        assert_eq!(recovered.bytes(), dek.bytes());
+
+        // Recovery re-provisions the keychain path: silent unlock works again.
+        assert_eq!(svc.state(true).unwrap(), KeyState::Ready);
+        assert_eq!(svc.unlock().unwrap().bytes(), dek.bytes());
+    }
+
+    #[test]
+    fn blob_swap_attack_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = svc(dir.path());
+        let (_, _recovery) = svc.provision().unwrap();
+        // Adversary (or confused sync tool) copies the recovery blob over
+        // the keychain blob. Even with the right KEK, AAD binding rejects it.
+        fs::copy(&svc.recovery_blob, &svc.keychain_blob).unwrap();
+        assert!(matches!(svc.unlock(), Err(KeyError::IntegrityFailure)));
+    }
+
+    #[test]
+    fn debug_output_is_redacted() {
+        let dek = Dek::generate();
+        let rk = RecoveryKey::generate();
+        assert_eq!(format!("{dek:?}"), "Dek(<redacted>)");
+        assert_eq!(format!("{rk:?}"), "RecoveryKey(<redacted>)");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn blob_files_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let svc = svc(dir.path());
+        svc.provision().unwrap();
+        for p in [&svc.keychain_blob, &svc.recovery_blob] {
+            let mode = fs::metadata(p).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "{p:?} must be owner-only");
+        }
+    }
+}

--- a/crates/wkyt-vault/src/lib.rs
+++ b/crates/wkyt-vault/src/lib.rs
@@ -1,6 +1,27 @@
 //! Encrypted SQLite vault (Milestone 2).
 //!
-//! Will own: the sqlcipher database (D1/D10), the KEK/DEK key service and
-//! recovery wrappers (D12), the `items`/`cursors` schema with
-//! `UNIQUE(connector_id, source_id)` (D13), and transactional batch-apply —
-//! deltas and the sync cursor committed as one unit (D11).
+//! Implements D12's two-tier key hierarchy and D1/D10's sqlcipher storage:
+//!
+//! - [`keys::KeyService`] — provisions and unlocks the **DEK** (data
+//!   encryption key, what sqlcipher receives) wrapped under two
+//!   interchangeable **KEKs**: one held in the OS keychain (silent unlock
+//!   on the login session), one derived from the user-held recovery key
+//!   (D8 ceremony). Either wrapper opens the vault; losing the keychain is
+//!   recoverable without re-encrypting anything.
+//! - [`vault::Vault`] — opens the sqlcipher database with a raw-key
+//!   `PRAGMA key`, fails closed on wrong key or plaintext files, and
+//!   applies the D9 hardening (0600 permissions, in-memory temp store,
+//!   sqlcipher memory security).
+//!
+//! Memory-handling rules (D12): key material lives only in
+//! `Zeroizing` buffers, is never formatted into errors or `Debug` output,
+//! and the hex/SQL strings momentarily needed for `PRAGMA key` are
+//! zeroized immediately after use. What we cannot control is documented
+//! at the relevant call sites rather than hidden.
+
+mod hexfmt;
+pub mod keys;
+pub mod vault;
+
+pub use keys::{Dek, KeyError, KeyService, KeyState, KeyringStore, KekStore, MemoryKekStore, RecoveryKey};
+pub use vault::{Vault, VaultError};

--- a/crates/wkyt-vault/src/vault.rs
+++ b/crates/wkyt-vault/src/vault.rs
@@ -1,0 +1,253 @@
+//! sqlcipher vault initialization (T2.3).
+//!
+//! The DEK is applied as a *raw* key (`PRAGMA key = "x'<hex>'"`), not a
+//! passphrase: sqlcipher then skips its PBKDF2 derivation, which is both
+//! correct (our DEK is already a uniformly random 256-bit key) and avoids
+//! pretending a KDF adds anything on top of one.
+//!
+//! Memory handling around `PRAGMA key` (D12), in order of custody:
+//!  1. `Dek` — `Zeroizing<[u8;32]>`, zeroized on drop.
+//!  2. The hex expansion and the composed `PRAGMA` SQL string — both
+//!     `Zeroizing<String>`, dropped (and erased) immediately after the
+//!     statement executes.
+//!  3. Beyond our control, documented honestly: `sqlite3_prepare` copies
+//!     the SQL text into SQLite's own heap, and sqlcipher retains the raw
+//!     key internally for the life of the connection. Mitigation:
+//!     `PRAGMA cipher_memory_security = ON`, which makes sqlcipher
+//!     mlock/zero its internal crypto buffers (small perf cost, right
+//!     trade for a personal vault).
+//!
+//! Fail-closed: after keying, we immediately query `sqlite_master`. With a
+//! wrong key or a plaintext/corrupt file, sqlcipher returns NOTADB and we
+//! refuse the connection — there is no path where the vault silently
+//! operates unencrypted.
+
+use crate::hexfmt;
+use crate::keys::Dek;
+use rusqlite::Connection;
+use std::path::Path;
+use zeroize::Zeroizing;
+
+#[derive(Debug, thiserror::Error)]
+pub enum VaultError {
+    /// Wrong DEK, tampered file, or a plaintext database where the vault
+    /// should be. Deliberately one variant: callers get no oracle.
+    #[error("vault cannot be opened: wrong key or not an encrypted vault")]
+    WrongKeyOrCorrupt,
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub struct Vault {
+    conn: Connection,
+}
+
+impl Vault {
+    /// Open (creating if absent) the encrypted vault at `path` with `dek`.
+    pub fn open(path: &Path, dek: &Dek) -> Result<Self, VaultError> {
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        let conn = Connection::open(path)?;
+        apply_key(&conn, dek)?;
+
+        // Fail-closed verification: first real page read. Wrong key or a
+        // plaintext SQLite file surfaces as NOTADB here.
+        conn.query_row("SELECT count(*) FROM sqlite_master", [], |r| r.get::<_, i64>(0))
+            .map_err(map_notadb)?;
+
+        conn.execute_batch(
+            // cipher_memory_security: sqlcipher locks + wipes its internal
+            //   crypto buffers (see module docs).
+            // temp_store = MEMORY: the D10 follow-up, made explicit instead
+            //   of assumed — SQLite temp b-trees/spill stay off disk, so no
+            //   plaintext intermediate files (Spec: nothing plaintext on disk).
+            // foreign_keys: schema integrity from day one (T2.4 schema).
+            "PRAGMA cipher_memory_security = ON;
+             PRAGMA temp_store = MEMORY;
+             PRAGMA foreign_keys = ON;
+             CREATE TABLE IF NOT EXISTS vault_meta (
+                 key   TEXT PRIMARY KEY,
+                 value TEXT NOT NULL
+             );",
+        )
+        .map_err(map_notadb)?;
+
+        restrict_permissions(path)?;
+        Ok(Self { conn })
+    }
+
+    /// Small KV surface for vault bookkeeping (schema version, ceremony
+    /// acknowledgement flag, …). The items/cursors schema lands in T2.4.
+    pub fn put_meta(&self, key: &str, value: &str) -> Result<(), VaultError> {
+        self.conn.execute(
+            "INSERT INTO vault_meta (key, value) VALUES (?1, ?2)
+             ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+            (key, value),
+        )?;
+        Ok(())
+    }
+
+    pub fn get_meta(&self, key: &str) -> Result<Option<String>, VaultError> {
+        use rusqlite::OptionalExtension;
+        Ok(self
+            .conn
+            .query_row("SELECT value FROM vault_meta WHERE key = ?1", (key,), |r| r.get(0))
+            .optional()?)
+    }
+}
+
+fn apply_key(conn: &Connection, dek: &Dek) -> Result<(), VaultError> {
+    // Raw-key form. The hex and the composed SQL both hold key material:
+    // both are Zeroizing and die at the end of this function.
+    let hex = Zeroizing::new(hexfmt::encode(dek.bytes()));
+    let sql = Zeroizing::new(format!("PRAGMA key = \"x'{}'\";", hex.as_str()));
+    conn.execute_batch(&sql)?;
+    Ok(())
+}
+
+fn map_notadb(e: rusqlite::Error) -> VaultError {
+    match &e {
+        rusqlite::Error::SqliteFailure(f, _)
+            if f.code == rusqlite::ErrorCode::NotADatabase =>
+        {
+            VaultError::WrongKeyOrCorrupt
+        }
+        _ => VaultError::Sqlite(e),
+    }
+}
+
+/// D9: vault files are owner-only. Covers the main DB and, when present,
+/// WAL/journal sidecars (their *contents* are sqlcipher-encrypted; this is
+/// belt and braces).
+fn restrict_permissions(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        for candidate in [
+            path.to_path_buf(),
+            path.with_extension("db-wal"),
+            path.with_extension("db-shm"),
+            path.with_extension("db-journal"),
+        ] {
+            if candidate.exists() {
+                std::fs::set_permissions(&candidate, std::fs::Permissions::from_mode(0o600))?;
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keys::{KeyService, MemoryKekStore};
+    use std::io::Read;
+
+    fn provision(dir: &Path) -> Dek {
+        let svc = KeyService::new(MemoryKekStore::default(), dir);
+        let (dek, _recovery) = svc.provision().unwrap();
+        dek
+    }
+
+    #[test]
+    fn write_close_reopen_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("vault.db");
+        let dek = provision(dir.path());
+
+        {
+            let vault = Vault::open(&db, &dek).unwrap();
+            vault.put_meta("schema_version", "1").unwrap();
+        } // connection dropped/closed
+
+        let vault = Vault::open(&db, &dek).unwrap();
+        assert_eq!(vault.get_meta("schema_version").unwrap().as_deref(), Some("1"));
+        assert_eq!(vault.get_meta("missing").unwrap(), None);
+    }
+
+    #[test]
+    fn wrong_dek_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("vault.db");
+        let dek = provision(dir.path());
+        Vault::open(&db, &dek).unwrap();
+
+        // A different provisioning yields a different DEK.
+        let other_dir = tempfile::tempdir().unwrap();
+        let wrong = provision(other_dir.path());
+        assert!(matches!(
+            Vault::open(&db, &wrong),
+            Err(VaultError::WrongKeyOrCorrupt)
+        ));
+    }
+
+    #[test]
+    fn db_file_on_disk_is_not_plaintext_sqlite() {
+        // Spec DoD #6: `file` must not identify the vault as SQLite.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("vault.db");
+        let dek = provision(dir.path());
+        let vault = Vault::open(&db, &dek).unwrap();
+        vault.put_meta("k", "v").unwrap();
+        drop(vault);
+
+        let mut header = [0u8; 16];
+        std::fs::File::open(&db).unwrap().read_exact(&mut header).unwrap();
+        assert_ne!(
+            &header,
+            b"SQLite format 3\0",
+            "vault file must not carry a plaintext SQLite header"
+        );
+    }
+
+    #[test]
+    fn plaintext_db_at_vault_path_is_rejected() {
+        // A pre-existing UNencrypted database (e.g. the old DuckDB/SQLite
+        // file, or an attacker-planted one) must not be silently adopted.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("vault.db");
+        rusqlite::Connection::open(&db)
+            .unwrap()
+            .execute_batch("CREATE TABLE t (x); INSERT INTO t VALUES (1);")
+            .unwrap();
+
+        let dek = provision(dir.path());
+        assert!(matches!(
+            Vault::open(&db, &dek),
+            Err(VaultError::WrongKeyOrCorrupt)
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn vault_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("vault.db");
+        let dek = provision(dir.path());
+        Vault::open(&db, &dek).unwrap();
+        let mode = std::fs::metadata(&db).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn temp_store_is_memory() {
+        // D10 follow-up, asserted rather than assumed.
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("vault.db");
+        let dek = provision(dir.path());
+        let vault = Vault::open(&db, &dek).unwrap();
+        let v: i64 = vault
+            .conn
+            .query_row("PRAGMA temp_store", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, 2, "temp_store must be MEMORY (2)");
+    }
+}


### PR DESCRIPTION
…her vault init (T2.1-T2.3)

AWAITING SECURITY REVIEW (Spec: auth/encryption changes require Eric's review before merge).

T2.1 keys.rs: D12 hierarchy. Random 256-bit DEK wrapped twice with XChaCha20-Poly1305 — once under a keychain-held KEK (silent cold start), once under the user-held recovery key. AAD binds blob purpose + version (blob-swap fails closed). KekStore trait: keyring-backed production store, in-memory test store, headless passphrase fallback slot for M6. Crash-safe provisioning order (keychain blob written last) with atomic tmp+rename writes, 0600 from creation.

T2.2 recovery ceremony primitives: display-once grouped-hex recovery key, lenient re-entry parsing, verify_recovery() proving the user saved it (amended D8); recover() re-keys the keychain path without touching the recovery wrapper.

T2.3 vault.rs: raw-key PRAGMA key (x'hex' form, no PBKDF2 on a random key); fail-closed sqlite_master probe maps NOTADB to one opaque WrongKeyOrCorrupt (plaintext-db-at-path rejected); cipher_memory_security ON; temp_store=MEMORY asserted (D10 follow-up); vault_meta KV; 0600.

Memory: all key buffers Zeroizing incl. the PRAGMA hex/SQL strings; Debug redacted for Dek/RecoveryKey; no key bytes in any error variant.

18 new tests (36 workspace total): round-trip, tamper, purpose-swap, keychain-loss recovery, wrong-key, plaintext-header, perms.

https://claude.ai/code/session_014HNypS7m7m4ho8DKJriNk6