### PR TITLE
feat: M3+M4 — Bus trait with bounded in-process transport, file-impor…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5387,13 +5387,36 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tokio",
+ "wkyt-connector-file",
  "wkyt-core",
+ "wkyt-host",
  "wkyt-vault",
 ]
 
 [[package]]
 name = "wkyt-broker"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "thiserror 2.0.18",
+ "tokio",
+ "wkyt-core",
+]
+
+[[package]]
+name = "wkyt-connector-file"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "wkyt-core",
+]
 
 [[package]]
 name = "wkyt-core"
@@ -5416,6 +5439,16 @@ dependencies = [
 [[package]]
 name = "wkyt-host"
 version = "0.1.0"
+dependencies = [
+ "futures-util",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "wkyt-broker",
+ "wkyt-connector-file",
+ "wkyt-core",
+ "wkyt-vault",
+]
 
 [[package]]
 name = "wkyt-vault"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/wkyt-core",
     "crates/wkyt-vault",
     "crates/wkyt-broker",
+    "crates/wkyt-connector-file",
     "crates/wkyt-host",
     "desktop/wkyt/src-tauri",
 ]
@@ -21,6 +22,13 @@ authors = ["Eric Ortego & Friends"]
 # Internal crates
 wkyt-core = { path = "crates/wkyt-core" }
 wkyt-vault = { path = "crates/wkyt-vault" }
+wkyt-broker = { path = "crates/wkyt-broker" }
+wkyt-connector-file = { path = "crates/wkyt-connector-file" }
+wkyt-host = { path = "crates/wkyt-host" }
+
+# Async runtime primitives. default-features = false: each crate enables
+# only what it uses (broker: sync; host: rt/sync/time; app: time).
+tokio = { version = "1", default-features = false }
 
 # Serialization of domain types (Item, deltas) and Tauri IPC payloads.
 serde = { version = "1", features = ["derive"] }

--- a/crates/wkyt-broker/Cargo.toml
+++ b/crates/wkyt-broker/Cargo.toml
@@ -1,10 +1,20 @@
 [package]
 name = "wkyt-broker"
-description = "Bus trait and in-process delta transport (lands in M3)"
+description = "Bus trait and bounded in-process delta transport (D11)"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 
-# Intentionally empty until M3: stub crates carry no dependencies
-# (Spec: every dependency must justify its existence).
 [dependencies]
+# DeltaBatch, the unit of transport.
+wkyt-core = { workspace = true }
+# Bounded mpsc channel — the entire in-process transport (D11).
+tokio = { workspace = true, features = ["sync"] }
+# async fn in the object-safe Bus traits.
+async-trait = { workspace = true }
+# BusError.
+thiserror = { workspace = true }
+
+[dev-dependencies]
+# Runtime + macros + timeouts for channel-behavior tests.
+tokio = { workspace = true, features = ["rt", "macros", "time"] }

--- a/crates/wkyt-broker/src/lib.rs
+++ b/crates/wkyt-broker/src/lib.rs
@@ -1,6 +1,209 @@
-//! Delta transport (Milestone 3).
+//! Delta transport (D11): the `Bus` trait pair and its default bounded
+//! in-process implementation.
 //!
-//! Will own the `Bus` trait and its default in-process bounded-channel
-//! implementation (D11). The trait keeps the transport swappable: if a
-//! future phase needs multi-process ingestion, a broker-backed `Bus` can be
-//! added without touching connectors or the vault.
+//! Contract recap from D11: the bus is a *dumb pipe with backpressure*.
+//! Durability does NOT live here — it lives in the vault, where each
+//! batch commits atomically with its cursor, and replay-from-cursor is
+//! idempotent (D13). The explicit [`Delivery::ack`] exists so the
+//! consumer's "ack only after the vault transaction commits" discipline
+//! is visible in the type system today and maps onto a real broker's ack
+//! if a multi-process transport ever replaces this one.
+//!
+//! In-process semantics, stated honestly:
+//! - `publish` awaits when the channel is full — that IS the backpressure.
+//! - An un-acked `Delivery` dropped on the floor is not redelivered by the
+//!   bus; the un-advanced cursor redelivers it on the next sync instead.
+//! - Ack bookkeeping (`published()` / `acked()`) lets tests assert the
+//!   ack-after-commit ordering.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use wkyt_core::DeltaBatch;
+
+#[derive(Debug, thiserror::Error)]
+pub enum BusError {
+    #[error("bus is closed (subscriber dropped)")]
+    Closed,
+}
+
+/// Producer half: connectors (via the orchestrator pump) publish batches.
+#[async_trait::async_trait]
+pub trait BusPublisher: Send + Sync {
+    /// Awaits when the transport is at capacity (backpressure), errors when
+    /// the consumer is gone.
+    async fn publish(&self, batch: DeltaBatch) -> Result<(), BusError>;
+}
+
+/// Consumer half: the vault-side orchestrator pulls deliveries.
+#[async_trait::async_trait]
+pub trait BusSubscriber: Send {
+    /// `None` means the bus is closed and drained: every publisher is gone
+    /// and nothing remains in flight.
+    async fn next(&mut self) -> Option<Delivery>;
+}
+
+/// One batch in flight. Call [`Delivery::into_parts`] and ack **only after
+/// the batch's vault transaction has committed**.
+pub struct Delivery {
+    batch: DeltaBatch,
+    ack: Ack,
+}
+
+impl Delivery {
+    pub fn batch(&self) -> &DeltaBatch {
+        &self.batch
+    }
+
+    pub fn into_parts(self) -> (DeltaBatch, Ack) {
+        (self.batch, self.ack)
+    }
+}
+
+/// Acknowledgement handle. Consuming `self` is deliberate: a delivery can
+/// be acked at most once, and dropping it un-acked is a visible decision.
+pub struct Ack(Box<dyn FnOnce() + Send>);
+
+impl Ack {
+    pub fn ack(self) {
+        (self.0)()
+    }
+}
+
+/// Create a bounded in-process bus. `capacity` is the maximum number of
+/// batches in flight before `publish` blocks the producer.
+pub fn in_process(capacity: usize) -> (InProcessPublisher, InProcessSubscriber) {
+    assert!(capacity > 0, "a zero-capacity bus cannot move anything");
+    let (tx, rx) = mpsc::channel(capacity);
+    let counters = Arc::new(Counters::default());
+    (
+        InProcessPublisher { tx, counters: Arc::clone(&counters) },
+        InProcessSubscriber { rx, counters },
+    )
+}
+
+#[derive(Default)]
+struct Counters {
+    published: AtomicU64,
+    acked: AtomicU64,
+}
+
+pub struct InProcessPublisher {
+    tx: mpsc::Sender<DeltaBatch>,
+    counters: Arc<Counters>,
+}
+
+impl InProcessPublisher {
+    /// Batches accepted by the bus so far (test/diagnostic surface).
+    pub fn published(&self) -> u64 {
+        self.counters.published.load(Ordering::SeqCst)
+    }
+
+    /// Deliveries the consumer has acked so far (test/diagnostic surface).
+    pub fn acked(&self) -> u64 {
+        self.counters.acked.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl BusPublisher for InProcessPublisher {
+    async fn publish(&self, batch: DeltaBatch) -> Result<(), BusError> {
+        self.tx.send(batch).await.map_err(|_| BusError::Closed)?;
+        self.counters.published.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+pub struct InProcessSubscriber {
+    rx: mpsc::Receiver<DeltaBatch>,
+    counters: Arc<Counters>,
+}
+
+#[async_trait::async_trait]
+impl BusSubscriber for InProcessSubscriber {
+    async fn next(&mut self) -> Option<Delivery> {
+        let batch = self.rx.recv().await?;
+        let counters = Arc::clone(&self.counters);
+        Some(Delivery {
+            batch,
+            ack: Ack(Box::new(move || {
+                counters.acked.fetch_add(1, Ordering::SeqCst);
+            })),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn batch(n: u32) -> DeltaBatch {
+        DeltaBatch {
+            connector_id: "test".into(),
+            deltas: vec![],
+            cursor: Some(wkyt_core::SyncToken(format!("c{n}"))),
+        }
+    }
+
+    #[tokio::test]
+    async fn delivers_in_order_and_tracks_acks() {
+        let (publisher, mut subscriber) = in_process(8);
+        publisher.publish(batch(1)).await.unwrap();
+        publisher.publish(batch(2)).await.unwrap();
+        assert_eq!(publisher.published(), 2);
+        assert_eq!(publisher.acked(), 0);
+
+        let d1 = subscriber.next().await.unwrap();
+        assert_eq!(d1.batch().cursor.as_ref().unwrap().0, "c1");
+        let (_, ack) = d1.into_parts();
+        ack.ack();
+        assert_eq!(publisher.acked(), 1);
+
+        let d2 = subscriber.next().await.unwrap();
+        assert_eq!(d2.batch().cursor.as_ref().unwrap().0, "c2");
+        // Dropped un-acked: bus does not count it, and does not redeliver —
+        // the cursor mechanism owns redelivery.
+        drop(d2);
+        assert_eq!(publisher.acked(), 1);
+    }
+
+    #[tokio::test]
+    async fn full_bus_applies_backpressure_until_consumed() {
+        let (publisher, mut subscriber) = in_process(1);
+        publisher.publish(batch(1)).await.unwrap();
+
+        // Second publish must pend: the bus is at capacity.
+        let second = publisher.publish(batch(2));
+        tokio::pin!(second);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut second).await.is_err(),
+            "publish into a full bus must wait, not drop or error"
+        );
+
+        // Consuming one frees the slot and the pending publish completes.
+        let d = subscriber.next().await.unwrap();
+        d.into_parts().1.ack();
+        tokio::time::timeout(Duration::from_millis(200), second)
+            .await
+            .expect("publish should complete once capacity frees")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn closed_bus_reports_closed_to_publishers_and_drains_for_consumers() {
+        let (publisher, mut subscriber) = in_process(4);
+        publisher.publish(batch(1)).await.unwrap();
+
+        // Consumer side: after all publishers drop, remaining items drain,
+        // then next() returns None.
+        drop(publisher);
+        assert!(subscriber.next().await.is_some());
+        assert!(subscriber.next().await.is_none());
+
+        // Publisher side: a dropped subscriber surfaces as Closed.
+        let (publisher, subscriber) = in_process(4);
+        drop(subscriber);
+        assert!(matches!(publisher.publish(batch(1)).await, Err(BusError::Closed)));
+    }
+}

--- a/crates/wkyt-connector-file/Cargo.toml
+++ b/crates/wkyt-connector-file/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "wkyt-connector-file"
+description = "Native file-importer connector: watches a directory of .json/.ics files (M4)"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[dependencies]
+# The Connector contract, Item/Delta types, SyncError taxonomy.
+wkyt-core = { workspace = true }
+# Cursor (de)serialization — the cursor is a JSON document inside the
+# opaque SyncToken — and parsing .json file contents.
+serde = { workspace = true }
+serde_json = { workspace = true }
+# File mtimes -> event timestamps.
+chrono = { workspace = true }
+# stream::iter to expose planned batches as the lazy DeltaStream.
+futures-util = { workspace = true }
+# Implementing the async Connector trait.
+async-trait = { workspace = true }
+
+[dev-dependencies]
+# Isolated watch directories per test.
+tempfile = "3"
+# Runtime for draining sync streams in tests.
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/wkyt-connector-file/src/lib.rs
+++ b/crates/wkyt-connector-file/src/lib.rs
@@ -1,0 +1,361 @@
+//! File-importer connector (M4): watches one local directory,
+//! non-recursively, for `.json` and `.ics` files.
+//!
+//! Cursor design — why mtime alone is not enough: a file *copied into* the
+//! watch dir keeps its original (possibly old) modification time, and a
+//! *deleted* file has no mtime at all. The cursor is therefore a JSON
+//! document inside the opaque `SyncToken`:
+//!
+//! ```json
+//! { "last_mtime_ms": 1720000000000, "known": ["a.json", "b.ics"] }
+//! ```
+//!
+//! A file is selected when its mtime is newer than `last_mtime_ms` OR its
+//! name is not in `known` (catches old-mtime copies). A name in `known`
+//! that is missing on disk becomes a [`Delta::Tombstone`]. A cursor that
+//! fails to parse yields `SyncError::ResyncRequired` — the orchestrator
+//! discards it and full-syncs, exactly the taxonomy's purpose.
+//!
+//! Batches are planned up front from *metadata only* (cheap), then file
+//! contents are read lazily one batch at a time as the stream is polled —
+//! memory stays O(batch), not O(directory). Each batch carries a cursor
+//! that is a valid resume point after that batch commits.
+//!
+//! Known limits, deliberate for M4: same-millisecond re-modification of a
+//! known file is missed until its next touch (mtime granularity); reads
+//! are synchronous std::fs (local files, bounded size); files larger than
+//! [`MAX_FILE_BYTES`] are indexed by metadata but their content is not
+//! ingested.
+
+use chrono::{DateTime, Utc};
+use futures_util::{stream, StreamExt as _};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::time::UNIX_EPOCH;
+use wkyt_core::{Connector, Delta, DeltaBatch, DeltaStream, Item, ItemKind, SyncError, SyncToken};
+
+/// Content above this size is not ingested (metadata still is).
+pub const MAX_FILE_BYTES: u64 = 4 * 1024 * 1024;
+const DEFAULT_BATCH_SIZE: usize = 64;
+const EXTENSIONS: [&str; 2] = ["json", "ics"];
+
+pub struct FileImporter {
+    id: String,
+    dir: PathBuf,
+    batch_size: usize,
+}
+
+#[derive(Serialize, Deserialize, Default, Clone)]
+struct FileCursor {
+    last_mtime_ms: i64,
+    known: BTreeSet<String>,
+}
+
+/// One pre-planned batch: names + mtimes only; contents read lazily.
+struct PlannedBatch {
+    tombstones: Vec<String>,
+    files: Vec<(String, i64)>, // (file name, mtime ms)
+    cursor: FileCursor,
+}
+
+impl FileImporter {
+    pub fn new(id: impl Into<String>, dir: PathBuf) -> Self {
+        Self { id: id.into(), dir, batch_size: DEFAULT_BATCH_SIZE }
+    }
+
+    /// Metadata-only scan and batch planning. No file contents touched.
+    fn plan(&self, cursor: Option<SyncToken>) -> Result<Vec<PlannedBatch>, SyncError> {
+        let prev: FileCursor = match cursor {
+            None => FileCursor::default(),
+            // Unintelligible cursor => the resume position is meaningless:
+            // signal a full resync rather than guessing.
+            Some(tok) => serde_json::from_str(&tok.0).map_err(|_| SyncError::ResyncRequired)?,
+        };
+
+        if !self.dir.is_dir() {
+            return Err(SyncError::Fatal {
+                source: format!("watch directory {:?} does not exist", self.dir).into(),
+            });
+        }
+
+        // Current state of the directory (names + mtimes).
+        let mut current: Vec<(String, i64)> = Vec::new();
+        let entries = std::fs::read_dir(&self.dir).map_err(retryable)?;
+        for entry in entries {
+            let entry = entry.map_err(retryable)?;
+            let path = entry.path();
+            let Some(ext) = path.extension().and_then(|e| e.to_str()) else { continue };
+            if !EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()) || !path.is_file() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else { continue };
+            let meta = entry.metadata().map_err(retryable)?;
+            let mtime_ms = meta
+                .modified()
+                .map_err(retryable)?
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            current.push((name.to_string(), mtime_ms));
+        }
+
+        let current_names: BTreeSet<String> = current.iter().map(|(n, _)| n.clone()).collect();
+        let deleted: Vec<String> =
+            prev.known.iter().filter(|n| !current_names.contains(*n)).cloned().collect();
+
+        // New or modified: newer mtime, or a name we have never seen
+        // (catches copied-in files that kept an old mtime).
+        let mut changed: Vec<(String, i64)> = current
+            .into_iter()
+            .filter(|(name, mtime)| *mtime > prev.last_mtime_ms || !prev.known.contains(name))
+            .collect();
+        changed.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+
+        let mut plans = Vec::new();
+        // Running cursor state, advanced batch by batch so every batch's
+        // cursor is a correct resume point once that batch commits.
+        let mut running = FileCursor {
+            last_mtime_ms: prev.last_mtime_ms,
+            known: prev.known.iter().filter(|n| current_names.contains(*n)).cloned().collect(),
+        };
+
+        if !deleted.is_empty() {
+            plans.push(PlannedBatch {
+                tombstones: deleted,
+                files: Vec::new(),
+                cursor: running.clone(),
+            });
+        }
+
+        for chunk in changed.chunks(self.batch_size) {
+            for (name, mtime) in chunk {
+                running.known.insert(name.clone());
+                running.last_mtime_ms = running.last_mtime_ms.max(*mtime);
+            }
+            plans.push(PlannedBatch {
+                tombstones: Vec::new(),
+                files: chunk.to_vec(),
+                cursor: running.clone(),
+            });
+        }
+        Ok(plans)
+    }
+
+    /// Read contents and materialize one planned batch. Called lazily as
+    /// the stream is polled.
+    fn build(&self, plan: PlannedBatch) -> Result<DeltaBatch, SyncError> {
+        let mut deltas: Vec<Delta> =
+            plan.tombstones.into_iter().map(|source_id| Delta::Tombstone { source_id }).collect();
+
+        for (name, mtime_ms) in plan.files {
+            let path = self.dir.join(&name);
+            let meta = std::fs::metadata(&path).map_err(retryable)?;
+            let timestamp = DateTime::<Utc>::from_timestamp_millis(mtime_ms)
+                .unwrap_or_else(Utc::now);
+
+            let mut properties = serde_json::json!({
+                "filename": name,
+                "extension": path.extension().and_then(|e| e.to_str()).unwrap_or(""),
+                "size_bytes": meta.len(),
+                "modified_ms": mtime_ms,
+            });
+            let mut raw_payload = None;
+
+            if meta.len() <= MAX_FILE_BYTES {
+                let content = std::fs::read_to_string(&path).map_err(retryable)?;
+                // .json contents become structured properties when they
+                // parse; anything else rides along as the raw string.
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&content) {
+                    properties["content"] = parsed;
+                }
+                raw_payload = Some(serde_json::Value::String(content));
+            } else {
+                properties["content_skipped"] = serde_json::json!("exceeds MAX_FILE_BYTES");
+            }
+
+            let mut item = Item::new(&name, &self.id, ItemKind::File, timestamp, properties);
+            item.raw_payload = raw_payload;
+            deltas.push(Delta::Upsert(item));
+        }
+
+        Ok(DeltaBatch {
+            connector_id: self.id.clone(),
+            deltas,
+            cursor: Some(SyncToken(
+                serde_json::to_string(&plan.cursor).expect("cursor serialization is infallible"),
+            )),
+        })
+    }
+}
+
+fn retryable(e: std::io::Error) -> SyncError {
+    SyncError::Retryable { source: Box::new(e), retry_after: None }
+}
+
+#[async_trait::async_trait]
+impl Connector for FileImporter {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn init(&self) -> Result<(), SyncError> {
+        std::fs::create_dir_all(&self.dir).map_err(retryable)?;
+        Ok(())
+    }
+
+    fn sync(&self, cursor: Option<SyncToken>) -> DeltaStream<'_> {
+        match self.plan(cursor) {
+            Err(e) => Box::pin(stream::iter(vec![Err(e)])),
+            Ok(plans) => {
+                Box::pin(stream::iter(plans).map(move |plan| self.build(plan)))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt;
+    use std::fs;
+    use std::path::Path;
+
+    fn importer(dir: &Path) -> FileImporter {
+        FileImporter::new("file-import", dir.to_path_buf())
+    }
+
+    async fn drain(c: &FileImporter, cursor: Option<SyncToken>) -> Vec<DeltaBatch> {
+        c.sync(cursor)
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+    }
+
+    fn upserts(batches: &[DeltaBatch]) -> Vec<&Item> {
+        batches
+            .iter()
+            .flat_map(|b| &b.deltas)
+            .filter_map(|d| match d {
+                Delta::Upsert(i) => Some(i),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn last_cursor(batches: &[DeltaBatch]) -> Option<SyncToken> {
+        batches.last().and_then(|b| b.cursor.clone())
+    }
+
+    #[tokio::test]
+    async fn full_sync_picks_up_supported_files_only() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a.json"), r#"{"k": 1}"#).unwrap();
+        fs::write(dir.path().join("b.ics"), "BEGIN:VCALENDAR\nEND:VCALENDAR").unwrap();
+        fs::write(dir.path().join("ignored.txt"), "nope").unwrap();
+
+        let c = importer(dir.path());
+        let batches = drain(&c, None).await;
+        let items = upserts(&batches);
+        assert_eq!(items.len(), 2);
+
+        let a = items.iter().find(|i| i.source_id == "a.json").unwrap();
+        assert_eq!(a.kind, ItemKind::File);
+        assert_eq!(a.properties["content"]["k"], 1, "json content becomes structured properties");
+        assert_eq!(a.id, Item::deterministic_id("file-import", "a.json").to_string());
+
+        let b = items.iter().find(|i| i.source_id == "b.ics").unwrap();
+        assert!(b.raw_payload.as_ref().unwrap().as_str().unwrap().contains("VCALENDAR"));
+    }
+
+    #[tokio::test]
+    async fn incremental_sync_sees_only_changes_and_copied_in_old_files() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a.json"), r#"{"v": 1}"#).unwrap();
+        let c = importer(dir.path());
+
+        let first = drain(&c, None).await;
+        let cursor = last_cursor(&first);
+
+        // Nothing changed: zero batches.
+        assert!(drain(&c, cursor.clone()).await.is_empty());
+
+        // A brand-new file with a deliberately ANCIENT mtime (simulates a
+        // copy that preserved timestamps) must still be selected, because
+        // it is not in the known set.
+        let old = dir.path().join("old.json");
+        fs::write(&old, r#"{"old": true}"#).unwrap();
+        let ancient = std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1000);
+        let f = fs::File::options().write(true).open(&old).unwrap();
+        f.set_modified(ancient).unwrap();
+        drop(f);
+
+        let second = drain(&c, cursor).await;
+        let items = upserts(&second);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].source_id, "old.json");
+    }
+
+    #[tokio::test]
+    async fn deletion_emits_tombstone() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a.json"), "{}").unwrap();
+        fs::write(dir.path().join("b.json"), "{}").unwrap();
+        let c = importer(dir.path());
+        let cursor = last_cursor(&drain(&c, None).await);
+
+        fs::remove_file(dir.path().join("b.json")).unwrap();
+        let batches = drain(&c, cursor).await;
+        let tombs: Vec<_> = batches
+            .iter()
+            .flat_map(|b| &b.deltas)
+            .filter_map(|d| match d {
+                Delta::Tombstone { source_id } => Some(source_id.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(tombs, vec!["b.json"]);
+
+        // And the tombstone is remembered: next sync is quiet.
+        assert!(drain(&c, last_cursor(&batches)).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn malformed_cursor_demands_full_resync() {
+        let dir = tempfile::tempdir().unwrap();
+        let c = importer(dir.path());
+        let mut s = c.sync(Some(SyncToken("not json at all".into())));
+        match s.next().await {
+            Some(Err(SyncError::ResyncRequired)) => {}
+            other => panic!("expected ResyncRequired, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn large_directories_stream_in_bounded_batches() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..10 {
+            fs::write(dir.path().join(format!("f{i:02}.json")), "{}").unwrap();
+        }
+        let mut c = importer(dir.path());
+        c.batch_size = 4;
+
+        let batches = drain(&c, None).await;
+        assert_eq!(batches.len(), 3, "10 files / batch_size 4 = 3 batches");
+        assert!(batches.iter().all(|b| b.cursor.is_some()), "every batch is a resume point");
+        assert_eq!(upserts(&batches).len(), 10);
+
+        // Resuming from the FIRST batch's cursor re-delivers only the rest.
+        let resumed = drain(&c, batches[0].cursor.clone()).await;
+        assert_eq!(upserts(&resumed).len(), 6, "first 4 already committed; 6 remain");
+    }
+
+    #[tokio::test]
+    async fn missing_watch_dir_is_fatal() {
+        let c = FileImporter::new("file-import", PathBuf::from("/nonexistent/wkyt-test"));
+        let mut s = c.sync(None);
+        assert!(matches!(s.next().await, Some(Err(SyncError::Fatal { .. }))));
+    }
+}

--- a/crates/wkyt-host/Cargo.toml
+++ b/crates/wkyt-host/Cargo.toml
@@ -1,10 +1,28 @@
 [package]
 name = "wkyt-host"
-description = "Connector orchestrator: scheduling, leases, backoff, error dispatch (lands in M4)"
+description = "Connector orchestrator: pumps connector streams onto the bus, applies to the vault, acks after commit"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
 
-# Intentionally empty until M4: stub crates carry no dependencies
-# (Spec: every dependency must justify its existence).
 [dependencies]
+# Connector contract, deltas, error taxonomy.
+wkyt-core = { workspace = true }
+# The transport between pump and consumer.
+wkyt-broker = { workspace = true }
+# The encrypted vault the consumer applies batches to.
+wkyt-vault = { workspace = true }
+# spawn for the consumer task + spawn_blocking for vault transactions.
+tokio = { workspace = true, features = ["rt", "sync"] }
+# StreamExt to drain connector delta streams.
+futures-util = { workspace = true }
+# HostError.
+thiserror = { workspace = true }
+
+[dev-dependencies]
+# The connector under end-to-end test.
+wkyt-connector-file = { workspace = true }
+# Isolated vault + watch dirs per test.
+tempfile = "3"
+# Test runtime.
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/wkyt-host/src/lib.rs
+++ b/crates/wkyt-host/src/lib.rs
@@ -1,6 +1,125 @@
-//! Connector orchestrator (Milestone 4).
+//! Connector orchestrator (M3/M4).
 //!
-//! Will own: per-connector sync leases (no concurrent syncs of one
-//! connector), backoff policy keyed by the `SyncError` taxonomy, the
-//! incremental→full resync fallback on `ResyncRequired`, and — in M5 —
-//! hosting WASM connectors behind the same `Connector` contract.
+//! One pipeline run = connector stream → bus → vault:
+//!
+//! ```text
+//! connector.sync(cursor) ──publish──> Bus ──next──> apply_batch ──commit──> ack
+//! ```
+//!
+//! The consumer acks a delivery **only after** [`Vault::apply_batch`]'s
+//! transaction commits — before that, a crash leaves the cursor
+//! un-advanced and the batch is simply re-delivered by the next run
+//! (idempotent by D13).
+//!
+//! Error policy by taxonomy (`SyncError`):
+//! - `ResyncRequired` mid-stream → the stored cursor is abandoned and the
+//!   sync restarts from `None`, once per run.
+//! - `Retryable` → surfaced to the caller; the caller's schedule (the app
+//!   polls) naturally retries from the committed cursor. In-run backoff
+//!   policy arrives with the orchestrator maturation work, as does the
+//!   per-connector lease (callers must not run one connector concurrently).
+//! - `AuthRequired` / `Fatal` → surfaced; the connector needs operator or
+//!   re-auth attention.
+
+use futures_util::StreamExt;
+use std::sync::{Arc, Mutex};
+use wkyt_broker::{in_process, BusError, BusPublisher, BusSubscriber};
+use wkyt_core::{Connector, SyncError, SyncToken};
+use wkyt_vault::{Vault, VaultError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum HostError {
+    #[error("connector: {0}")]
+    Sync(#[from] SyncError),
+    #[error("vault: {0}")]
+    Vault(#[from] VaultError),
+    #[error("bus: {0}")]
+    Bus(#[from] BusError),
+    #[error("consumer task panicked or was cancelled: {0}")]
+    Join(String),
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct PipelineStats {
+    pub batches_applied: u64,
+    pub deltas_applied: u64,
+}
+
+/// Run one full pipeline pass for `connector`: resume from the vault's
+/// committed cursor, stream batches over a bounded bus, apply each to the
+/// vault, ack after commit. Returns once the stream is drained and every
+/// in-flight batch is applied (or the first error).
+pub async fn run_pipeline_once<C: Connector + ?Sized>(
+    connector: &C,
+    vault: Arc<Mutex<Vault>>,
+) -> Result<PipelineStats, HostError> {
+    connector.init().await?;
+    let starting_cursor = vault.lock().unwrap().cursor(connector.id())?;
+
+    let (publisher, subscriber) = in_process(8);
+    let consumer = tokio::spawn(consume(subscriber, Arc::clone(&vault)));
+
+    let pump_result = pump(connector, &publisher, starting_cursor).await;
+
+    // Closing the publisher lets the consumer drain and finish.
+    drop(publisher);
+    let stats = consumer.await.map_err(|e| HostError::Join(e.to_string()))??;
+
+    // Consumer success with a pump failure still reports the pump failure:
+    // partial progress is durable (cursor committed per batch), and the
+    // caller's next run resumes from it.
+    pump_result?;
+    Ok(stats)
+}
+
+/// Drain the connector's stream into the bus, honoring the error taxonomy:
+/// `ResyncRequired` triggers exactly one restart from `None`; a second
+/// `ResyncRequired` (a full sync demanding a full resync) surfaces as the
+/// error it is rather than looping.
+async fn pump<C: Connector + ?Sized>(
+    connector: &C,
+    publisher: &impl BusPublisher,
+    starting_cursor: Option<SyncToken>,
+) -> Result<(), HostError> {
+    match drain_stream(connector, publisher, starting_cursor).await {
+        Err(HostError::Sync(SyncError::ResyncRequired)) => {
+            drain_stream(connector, publisher, None).await
+        }
+        other => other,
+    }
+}
+
+async fn drain_stream<C: Connector + ?Sized>(
+    connector: &C,
+    publisher: &impl BusPublisher,
+    cursor: Option<SyncToken>,
+) -> Result<(), HostError> {
+    let mut stream = connector.sync(cursor);
+    while let Some(next) = stream.next().await {
+        publisher.publish(next?).await?;
+    }
+    Ok(())
+}
+
+/// Pull deliveries, apply each batch in its own vault transaction, and ack
+/// strictly after commit.
+async fn consume<S: BusSubscriber>(
+    mut subscriber: S,
+    vault: Arc<Mutex<Vault>>,
+) -> Result<PipelineStats, HostError> {
+    let mut stats = PipelineStats::default();
+    while let Some(delivery) = subscriber.next().await {
+        let (batch, ack) = delivery.into_parts();
+        let delta_count = batch.deltas.len() as u64;
+        let v = Arc::clone(&vault);
+        // apply_batch is blocking (sqlite); keep it off the async threads.
+        tokio::task::spawn_blocking(move || v.lock().unwrap().apply_batch(&batch))
+            .await
+            .map_err(|e| HostError::Join(e.to_string()))??;
+        // The transaction is committed — and only now is it safe to ack.
+        ack.ack();
+        stats.batches_applied += 1;
+        stats.deltas_applied += delta_count;
+    }
+    Ok(stats)
+}

--- a/crates/wkyt-host/tests/e2e_pipeline.rs
+++ b/crates/wkyt-host/tests/e2e_pipeline.rs
@@ -1,0 +1,122 @@
+//! End-to-end pipeline: files on disk → FileImporter → bounded bus →
+//! encrypted sqlcipher vault, with ack-after-commit and cursor resume.
+
+use std::fs;
+use std::sync::{Arc, Mutex};
+use tempfile::TempDir;
+use wkyt_connector_file::FileImporter;
+use wkyt_core::{Item, SyncToken};
+use wkyt_host::run_pipeline_once;
+use wkyt_vault::{KeyService, MemoryKekStore, Vault};
+
+struct Rig {
+    _vault_dir: TempDir,
+    watch_dir: TempDir,
+    vault: Arc<Mutex<Vault>>,
+    connector: FileImporter,
+}
+
+fn rig() -> Rig {
+    let vault_dir = tempfile::tempdir().unwrap();
+    let watch_dir = tempfile::tempdir().unwrap();
+    let svc = KeyService::new(MemoryKekStore::default(), vault_dir.path());
+    let (dek, _recovery) = svc.provision().unwrap();
+    let vault = Vault::open(&vault_dir.path().join("vault.db"), &dek).unwrap();
+    let connector = FileImporter::new("file-import", watch_dir.path().to_path_buf());
+    Rig {
+        _vault_dir: vault_dir,
+        watch_dir,
+        vault: Arc::new(Mutex::new(vault)),
+        connector,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drop_modify_delete_lands_in_encrypted_vault() {
+    let r = rig();
+
+    // 1. Drop two files → both land.
+    fs::write(r.watch_dir.path().join("notes.json"), r#"{"note": "hello"}"#).unwrap();
+    fs::write(r.watch_dir.path().join("cal.ics"), "BEGIN:VCALENDAR\nEND:VCALENDAR").unwrap();
+
+    let stats = run_pipeline_once(&r.connector, Arc::clone(&r.vault)).await.unwrap();
+    assert_eq!(stats.batches_applied, 1);
+    assert_eq!(stats.deltas_applied, 2);
+    {
+        let v = r.vault.lock().unwrap();
+        assert_eq!(v.item_count().unwrap(), 2);
+        let items = v.items("file-import").unwrap();
+        let notes = items.iter().find(|i| i.source_id == "notes.json").unwrap();
+        assert_eq!(notes.properties["content"]["note"], "hello");
+        assert_eq!(
+            notes.id,
+            Item::deterministic_id("file-import", "notes.json").to_string()
+        );
+        assert!(v.cursor("file-import").unwrap().is_some(), "cursor committed with the batch");
+    }
+
+    // 2. Idle pass: nothing changed, nothing applied.
+    let stats = run_pipeline_once(&r.connector, Arc::clone(&r.vault)).await.unwrap();
+    assert_eq!(stats, wkyt_host::PipelineStats::default());
+
+    // 3. Modify → in-place update, no duplicate row.
+    fs::write(r.watch_dir.path().join("notes.json"), r#"{"note": "edited"}"#).unwrap();
+    let stats = run_pipeline_once(&r.connector, Arc::clone(&r.vault)).await.unwrap();
+    assert_eq!(stats.deltas_applied, 1);
+    {
+        let v = r.vault.lock().unwrap();
+        assert_eq!(v.item_count().unwrap(), 2, "modification must not duplicate");
+        let items = v.items("file-import").unwrap();
+        let notes = items.iter().find(|i| i.source_id == "notes.json").unwrap();
+        assert_eq!(notes.properties["content"]["note"], "edited");
+    }
+
+    // 4. Delete → tombstone; the row leaves the live set.
+    fs::remove_file(r.watch_dir.path().join("cal.ics")).unwrap();
+    run_pipeline_once(&r.connector, Arc::clone(&r.vault)).await.unwrap();
+    {
+        let v = r.vault.lock().unwrap();
+        assert_eq!(v.item_count().unwrap(), 1);
+        assert!(v.items("file-import").unwrap().iter().all(|i| i.source_id != "cal.ics"));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn corrupted_cursor_triggers_one_full_resync_without_duplicates() {
+    let r = rig();
+    fs::write(r.watch_dir.path().join("a.json"), "{}").unwrap();
+    run_pipeline_once(&r.connector, Arc::clone(&r.vault)).await.unwrap();
+
+    // Sabotage the stored cursor (simulates a cursor-format change or a
+    // source-side token expiry). The pump must fall back to a full resync.
+    {
+        let mut v = r.vault.lock().unwrap();
+        v.apply_batch(&wkyt_core::DeltaBatch {
+            connector_id: "file-import".into(),
+            deltas: vec![],
+            cursor: Some(SyncToken("garbage-not-json".into())),
+        })
+        .unwrap();
+    }
+
+    let stats = run_pipeline_once(&r.connector, Arc::clone(&r.vault)).await.unwrap();
+    assert_eq!(stats.deltas_applied, 1, "full resync re-delivers the file");
+    let v = r.vault.lock().unwrap();
+    assert_eq!(v.item_count().unwrap(), 1, "resync over existing data must not duplicate");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn many_files_flow_through_bounded_batches_with_per_batch_commits() {
+    let r = rig();
+    for i in 0..150 {
+        fs::write(r.watch_dir.path().join(format!("f{i:03}.json")), "{}").unwrap();
+    }
+
+    let stats = run_pipeline_once(&r.connector, Arc::clone(&r.vault)).await.unwrap();
+    assert_eq!(stats.deltas_applied, 150);
+    assert!(
+        stats.batches_applied >= 3,
+        "150 files at batch size 64 must arrive as multiple bounded batches"
+    );
+    assert_eq!(r.vault.lock().unwrap().item_count().unwrap(), 150);
+}

--- a/desktop/wkyt/src-tauri/Cargo.toml
+++ b/desktop/wkyt/src-tauri/Cargo.toml
@@ -28,6 +28,12 @@ wkyt-core = { workspace = true }
 # the interim DuckDB storage — and with it the bundled DuckDB C++ build
 # that was breaking the Windows CI leg.
 wkyt-vault = { workspace = true }
+# Pipeline orchestrator: connector -> bus -> vault with ack-after-commit.
+wkyt-host = { workspace = true }
+# The M4 file-importer connector driven by the debug pipeline.
+wkyt-connector-file = { workspace = true }
+# Polling interval for the debug import-folder watcher.
+tokio = { workspace = true, features = ["time"] }
 # Event timestamps when constructing items (e.g. MockConnector).
 chrono = { workspace = true }
 # Implementing the async Connector trait (MockConnector).

--- a/desktop/wkyt/src-tauri/src/lib.rs
+++ b/desktop/wkyt/src-tauri/src/lib.rs
@@ -1,8 +1,6 @@
 pub mod google_auth;
 pub mod lifegraph;
 
-#[cfg(debug_assertions)]
-use lifegraph::{Connector, MockConnector};
 use tauri::Manager;
 
 #[tauri::command]
@@ -58,12 +56,13 @@ pub fn run() {
 
             println!("Vault path: {:?}", db_path);
 
-            // Placeholder pipeline (debug only): mock connector -> encrypted
-            // vault, exercising the real cursor-resume and batch-apply path.
+            // Debug orchestrator (M3/M4): poll an import folder and run the
+            // full pipeline — FileImporter -> bounded bus -> encrypted
+            // vault, ack-after-commit, cursor resume across app restarts.
             #[cfg(debug_assertions)]
             tauri::async_runtime::spawn(async move {
-                use futures_util::StreamExt;
                 use std::sync::{Arc, Mutex};
+                use wkyt_connector_file::FileImporter;
 
                 let dir = app_data_dir.clone();
                 let db = db_path.clone();
@@ -83,47 +82,24 @@ pub fn run() {
                     }
                 };
 
-                let connector = MockConnector {
-                    id: "test-conn-01".to_string(),
-                };
-                if let Err(e) = connector.init().await {
-                    eprintln!("Connector init failed: {}", e);
-                    return;
-                }
+                let import_dir = app_data_dir.join("import");
+                let connector = FileImporter::new("file-import", import_dir.clone());
+                println!("[wkyt] watching {:?} — drop .json/.ics files there", import_dir);
 
-                // Resume from the committed cursor — None on first run.
-                let cursor = vault.lock().unwrap().cursor(connector.id()).ok().flatten();
-                let mut stream = connector.sync(cursor);
-                while let Some(batch) = stream.next().await {
-                    let batch = match batch {
-                        Ok(b) => b,
-                        Err(e) => {
-                            eprintln!("Sync failed: {}", e);
-                            break;
+                loop {
+                    match wkyt_host::run_pipeline_once(&connector, Arc::clone(&vault)).await {
+                        Ok(stats) if stats.batches_applied > 0 => {
+                            let live = vault.lock().unwrap().item_count().unwrap_or(-1);
+                            println!(
+                                "[wkyt] ingested {} deltas in {} batches; vault holds {} live items",
+                                stats.deltas_applied, stats.batches_applied, live
+                            );
                         }
-                    };
-                    let v = Arc::clone(&vault);
-                    let applied = tauri::async_runtime::spawn_blocking(move || {
-                        v.lock().unwrap().apply_batch(&batch)
-                    })
-                    .await;
-                    match applied {
-                        Ok(Ok(())) => {}
-                        Ok(Err(e)) => {
-                            eprintln!("Failed to apply batch: {}", e);
-                            break;
-                        }
-                        Err(e) => {
-                            eprintln!("Failed to join blocking task: {}", e);
-                            break;
-                        }
+                        Ok(_) => {} // quiet pass, nothing changed
+                        Err(e) => eprintln!("[wkyt] pipeline pass failed: {e}"),
                     }
+                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
                 }
-
-                match vault.lock().unwrap().item_count() {
-                    Ok(n) => println!("Vault now holds {} live items.", n),
-                    Err(e) => eprintln!("Failed to count items: {}", e),
-                };
             });
 
             Ok(())


### PR DESCRIPTION
…ter connector, E2E pipeline

M3 (wkyt-broker): BusPublisher/BusSubscriber traits + bounded tokio mpsc implementation per D11. publish() awaits at capacity (backpressure); Delivery::ack is consume-once and the consumer acks strictly after the vault transaction commits. The bus does NOT redeliver dropped deliveries — the un-advanced cursor owns redelivery (D11 durability model). Tests: ordering+ack accounting, backpressure, closed-bus semantics.

M3 (wkyt-host): run_pipeline_once = connector.sync(committed cursor) ->
bus -> apply_batch -> ack-after-commit. Error taxonomy honored: ResyncRequired restarts full exactly once; Retryable surfaces to the caller whose schedule retries from the committed cursor; Auth/Fatal surface. In-run backoff + per-connector leases deferred to orchestrator maturation (documented).

M4 (wkyt-connector-file): watches one dir, non-recursively, for .json/.ics. Cursor = {last_mtime_ms, known: [names]} as JSON inside the opaque SyncToken — mtime alone misses copied-in files (old mtimes) and cannot see deletions. Deletions emit Tombstones; malformed cursor yields ResyncRequired; batches planned from metadata and contents read lazily (O(batch) memory); >4MiB files indexed without content.

E2E: app debug orchestrator polls app_data/import every 10s through the full pipeline into the encrypted vault. Host integration tests cover drop/modify/delete, corrupted-cursor full resync without duplicates, and 150-file bounded-batch flow.

56 workspace tests green.

https://claude.ai/code/session_014HNypS7m7m4ho8DKJriNk6