### PR TITLE
feat: M4 viewer + recovery ceremony UI — vault commands, dashboard, f…

### DIFF
--- a/crates/wkyt-vault/src/keys.rs
+++ b/crates/wkyt-vault/src/keys.rs
@@ -431,6 +431,22 @@ impl<S: KekStore> KeyService<S> {
         unwrap(&read_blob(&staged)?, &kek, "keychain").map(Some)
     }
 
+    /// Destroy ALL key material (both blobs, staged blobs, the keychain
+    /// KEK) so a fresh `provision()` can run. Exists for exactly one flow:
+    /// a first-run ceremony abandoned before verification, where the vault
+    /// holds no user data and the displayed-once recovery key is gone for
+    /// good. CALLERS must enforce that guard (empty vault + ceremony
+    /// unverified) — this method cannot see the vault and will not check.
+    pub fn reset_for_reprovision(&self) -> Result<(), KeyError> {
+        self.discard_staged();
+        for blob in [&self.keychain_blob, &self.recovery_blob] {
+            if blob.exists() {
+                fs::remove_file(blob)?;
+            }
+        }
+        self.store.delete()
+    }
+
     /// Keychain-loss recovery: the recovery key unwraps the DEK, then a
     /// fresh KEK is generated, stored in the (new) keychain, and the
     /// keychain blob is re-wrapped. The recovery blob — and the user's
@@ -571,6 +587,20 @@ mod tests {
         // Recovery re-provisions the keychain path: silent unlock works again.
         assert_eq!(svc.state(true).unwrap(), KeyState::Ready);
         assert_eq!(svc.unlock().unwrap().bytes(), dek.bytes());
+    }
+
+    #[test]
+    fn reset_for_reprovision_returns_to_first_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let svc = svc(dir.path());
+        svc.provision().unwrap();
+        assert_eq!(svc.state(false).unwrap(), KeyState::Ready);
+
+        svc.reset_for_reprovision().unwrap();
+        assert_eq!(svc.state(false).unwrap(), KeyState::FirstRun);
+        // And a fresh provision works.
+        svc.provision().unwrap();
+        assert_eq!(svc.state(false).unwrap(), KeyState::Ready);
     }
 
     #[test]

--- a/crates/wkyt-vault/src/vault.rs
+++ b/crates/wkyt-vault/src/vault.rs
@@ -230,6 +230,25 @@ impl Vault {
         Ok(items)
     }
 
+    /// Live items across all connectors, newest event first — the viewer's
+    /// query (Spec DoD #7).
+    pub fn recent_items(&self, limit: u32) -> Result<Vec<Item>, VaultError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, connector_id, source_id, kind, timestamp_ms,
+                    ingested_at_ms, properties, raw_payload
+             FROM items
+             WHERE deleted_at_ms IS NULL
+             ORDER BY timestamp_ms DESC
+             LIMIT ?1",
+        )?;
+        let rows = stmt.query_map((limit,), row_to_item)?;
+        let mut items = Vec::new();
+        for row in rows {
+            items.push(row??);
+        }
+        Ok(items)
+    }
+
     /// Total live items across all connectors.
     pub fn item_count(&self) -> Result<i64, VaultError> {
         Ok(self.conn.query_row(

--- a/desktop/wkyt/src-tauri/src/lib.rs
+++ b/desktop/wkyt/src-tauri/src/lib.rs
@@ -1,112 +1,35 @@
 pub mod google_auth;
 pub mod lifegraph;
+pub mod vault_commands;
 
+use std::sync::Arc;
 use tauri::Manager;
-
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
-
-/// Cold-start key/vault bootstrap (D12). Blocking: call from a blocking
-/// thread. Returns an error string suitable for logging — never key bytes.
-#[cfg(debug_assertions)]
-fn open_vault(
-    data_dir: &std::path::Path,
-    db_path: &std::path::Path,
-) -> Result<wkyt_vault::Vault, String> {
-    use wkyt_vault::{unlock_vault, KeyService, KeyState, KeyringStore, Vault};
-
-    let svc = KeyService::new(KeyringStore::new("wkyt"), data_dir);
-    match svc.state(db_path.exists()).map_err(|e| e.to_string())? {
-        KeyState::FirstRun => {
-            let (dek, _recovery) = svc.provision().map_err(|e| e.to_string())?;
-            // The D8 recovery ceremony UI lands with the viewer work; until
-            // then the recovery key is deliberately dropped UNDISPLAYED
-            // (never logged — that would put a secret in plaintext logs).
-            // Acceptable only while this path is debug-only dev scaffolding.
-            eprintln!(
-                "[wkyt] vault provisioned. Recovery ceremony UI is pending — \
-                 until it ships, keychain loss means data loss on this profile."
-            );
-            Vault::open(db_path, &dek).map_err(|e| e.to_string())
-        }
-        KeyState::Ready => {
-            let (vault, _dek) = unlock_vault(&svc, db_path).map_err(|e| e.to_string())?;
-            Ok(vault)
-        }
-        KeyState::KeychainLost => Err(
-            "OS keychain entry is gone; recovery-key entry UI is pending (M4)".to_string()
-        ),
-        KeyState::Inconsistent(why) => Err(format!("key state inconsistent: {why}")),
-    }
-}
+use vault_commands::AppState;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .setup(|app| {
-            // Get the app data directory
             let app_data_dir = app
                 .path()
                 .app_data_dir()
                 .expect("failed to get app data dir");
             std::fs::create_dir_all(&app_data_dir).expect("failed to create app data dir");
-            let db_path = app_data_dir.join("vault.db");
 
-            println!("Vault path: {:?}", db_path);
-
-            // Debug orchestrator (M3/M4): poll an import folder and run the
-            // full pipeline — FileImporter -> bounded bus -> encrypted
-            // vault, ack-after-commit, cursor resume across app restarts.
-            #[cfg(debug_assertions)]
-            tauri::async_runtime::spawn(async move {
-                use std::sync::{Arc, Mutex};
-                use wkyt_connector_file::FileImporter;
-
-                let dir = app_data_dir.clone();
-                let db = db_path.clone();
-                let vault = match tauri::async_runtime::spawn_blocking(move || {
-                    open_vault(&dir, &db)
-                })
-                .await
-                {
-                    Ok(Ok(v)) => Arc::new(Mutex::new(v)),
-                    Ok(Err(e)) => {
-                        eprintln!("[wkyt] vault unavailable, ingestion skipped: {e}");
-                        return;
-                    }
-                    Err(e) => {
-                        eprintln!("[wkyt] vault open task failed: {e}");
-                        return;
-                    }
-                };
-
-                let import_dir = app_data_dir.join("import");
-                let connector = FileImporter::new("file-import", import_dir.clone());
-                println!("[wkyt] watching {:?} — drop .json/.ics files there", import_dir);
-
-                loop {
-                    match wkyt_host::run_pipeline_once(&connector, Arc::clone(&vault)).await {
-                        Ok(stats) if stats.batches_applied > 0 => {
-                            let live = vault.lock().unwrap().item_count().unwrap_or(-1);
-                            println!(
-                                "[wkyt] ingested {} deltas in {} batches; vault holds {} live items",
-                                stats.deltas_applied, stats.batches_applied, live
-                            );
-                        }
-                        Ok(_) => {} // quiet pass, nothing changed
-                        Err(e) => eprintln!("[wkyt] pipeline pass failed: {e}"),
-                    }
-                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-                }
-            });
-
+            // The vault lifecycle (unlock / first-run ceremony / recovery)
+            // is driven by the frontend through vault_commands; nothing is
+            // unlocked and no ingestion runs until the UI asks.
+            app.manage(Arc::new(AppState::new(app_data_dir)));
             Ok(())
         })
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![
-            greet,
+            vault_commands::vault_status,
+            vault_commands::begin_first_run,
+            vault_commands::verify_recovery_key,
+            vault_commands::recover_with_key,
+            vault_commands::get_items,
+            vault_commands::get_stats,
             google_auth::start_oauth,
             google_auth::logout,
             google_auth::exchange_code_for_token,

--- a/desktop/wkyt/src-tauri/src/vault_commands.rs
+++ b/desktop/wkyt/src-tauri/src/vault_commands.rs
@@ -1,0 +1,334 @@
+//! Tauri command surface for the vault: status/ceremony state machine,
+//! viewer queries, and the ingestion-pipeline starter.
+//!
+//! State machine driven by the frontend:
+//!
+//! ```text
+//! vault_status ──first_run──> begin_first_run ──> (key shown once)
+//!      │                          └─> verify_recovery_key ──ok──> READY
+//!      ├──ready────────────────────────────────────────────────> READY
+//!      └──keychain_lost──> recover_with_key ─────────────ok────> READY
+//! ```
+//!
+//! READY = vault cached in state + ingestion pipeline running. The
+//! pipeline NEVER starts before the ceremony verifies (or recovery
+//! proves the user holds the key): until then the vault stays empty,
+//! which is exactly what makes an abandoned ceremony safely resettable.
+//!
+//! Security notes: the recovery key string crosses to the webview once,
+//! at the ceremony (documented D8/D12 trade-off — the user must see it);
+//! it is never logged and never stored. Errors crossing to the UI are
+//! strings and carry no key material.
+
+use serde::Serialize;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use wkyt_connector_file::FileImporter;
+use wkyt_vault::{unlock_vault, KeyError, KeyService, KeyState, KeyringStore, Vault};
+
+const KEYRING_SERVICE: &str = "wkyt";
+const META_RECOVERY_VERIFIED: &str = "recovery_verified";
+
+pub struct AppState {
+    data_dir: PathBuf,
+    db_path: PathBuf,
+    import_dir: PathBuf,
+    /// Outer mutex guards set/replace; inner is the vault's own op lock.
+    vault: Mutex<Option<Arc<Mutex<Vault>>>>,
+    pipeline_started: AtomicBool,
+}
+
+impl AppState {
+    pub fn new(data_dir: PathBuf) -> Self {
+        Self {
+            db_path: data_dir.join("vault.db"),
+            import_dir: data_dir.join("import"),
+            data_dir,
+            vault: Mutex::new(None),
+            pipeline_started: AtomicBool::new(false),
+        }
+    }
+
+    fn key_service(&self) -> KeyService<KeyringStore> {
+        KeyService::new(KeyringStore::new(KEYRING_SERVICE), &self.data_dir)
+    }
+
+    fn cached_vault(&self) -> Option<Arc<Mutex<Vault>>> {
+        self.vault.lock().unwrap().clone()
+    }
+
+    fn cache_vault(&self, vault: Vault) -> Arc<Mutex<Vault>> {
+        let arc = Arc::new(Mutex::new(vault));
+        *self.vault.lock().unwrap() = Some(Arc::clone(&arc));
+        arc
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum VaultStatus {
+    /// No vault yet (or a ceremony was abandoned pre-verification):
+    /// run `begin_first_run`.
+    FirstRun,
+    Ready { live_items: i64 },
+    /// Wrapped DEK exists but the OS keychain entry is gone:
+    /// `recover_with_key`.
+    KeychainLost,
+    Inconsistent { reason: String },
+}
+
+#[derive(Serialize)]
+pub struct VaultStats {
+    pub live_items: i64,
+    pub import_dir: String,
+}
+
+/// Viewer projection of an Item: everything except `raw_payload`, which
+/// can be megabytes and has no business in a list view.
+#[derive(Serialize)]
+pub struct ItemView {
+    pub id: String,
+    pub connector_id: String,
+    pub source_id: String,
+    pub kind: serde_json::Value,
+    pub timestamp: String,
+    pub ingested_at: String,
+    pub properties: serde_json::Value,
+}
+
+fn verified(vault: &Arc<Mutex<Vault>>) -> Result<bool, String> {
+    Ok(vault
+        .lock()
+        .unwrap()
+        .get_meta(META_RECOVERY_VERIFIED)
+        .map_err(|e| e.to_string())?
+        .as_deref()
+        == Some("true"))
+}
+
+fn start_pipeline(app: &tauri::AppHandle, state: &AppState) {
+    if state.pipeline_started.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let vault = state.cached_vault().expect("pipeline started before vault ready");
+    let connector = FileImporter::new("file-import", state.import_dir.clone());
+    println!("[wkyt] watching {:?} — drop .json/.ics files there", state.import_dir);
+    let _app = app.clone(); // reserved for emitting ingest events to the UI later
+    tauri::async_runtime::spawn(async move {
+        loop {
+            match wkyt_host::run_pipeline_once(&connector, Arc::clone(&vault)).await {
+                Ok(stats) if stats.batches_applied > 0 => {
+                    println!(
+                        "[wkyt] ingested {} deltas in {} batches",
+                        stats.deltas_applied, stats.batches_applied
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => eprintln!("[wkyt] pipeline pass failed: {e}"),
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        }
+    });
+}
+
+#[tauri::command]
+pub async fn vault_status(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<VaultStatus, String> {
+    let s = Arc::clone(&state);
+    let app2 = app.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        // Already unlocked this session?
+        if let Some(vault) = s.cached_vault() {
+            return if verified(&vault)? {
+                start_pipeline(&app2, &s);
+                let live = vault.lock().unwrap().item_count().map_err(|e| e.to_string())?;
+                Ok(VaultStatus::Ready { live_items: live })
+            } else {
+                // Ceremony in flight or abandoned: the UI restarts it.
+                Ok(VaultStatus::FirstRun)
+            };
+        }
+
+        let svc = s.key_service();
+        match svc.state(s.db_path.exists()).map_err(|e| e.to_string())? {
+            KeyState::FirstRun => Ok(VaultStatus::FirstRun),
+            KeyState::KeychainLost => Ok(VaultStatus::KeychainLost),
+            KeyState::Inconsistent(reason) => {
+                Ok(VaultStatus::Inconsistent { reason: reason.to_string() })
+            }
+            KeyState::Ready => {
+                let (vault, _dek) = unlock_vault(&svc, &s.db_path).map_err(|e| e.to_string())?;
+                let vault = s.cache_vault(vault);
+                if verified(&vault)? {
+                    start_pipeline(&app2, &s);
+                    let live = vault.lock().unwrap().item_count().map_err(|e| e.to_string())?;
+                    Ok(VaultStatus::Ready { live_items: live })
+                } else {
+                    // Provisioned but the ceremony never verified — the key
+                    // was shown once and is unrecoverable. The vault is
+                    // guaranteed empty (pipeline gates on verification), so
+                    // begin_first_run will reset and re-provision.
+                    Ok(VaultStatus::FirstRun)
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Provision (or safely re-provision after an abandoned ceremony) and
+/// return the recovery key for display. The ONLY time it ever crosses to
+/// the UI.
+#[tauri::command]
+pub async fn begin_first_run(state: tauri::State<'_, Arc<AppState>>) -> Result<String, String> {
+    let s = Arc::clone(&state);
+    tauri::async_runtime::spawn_blocking(move || {
+        let svc = s.key_service();
+
+        // Abandoned-ceremony reset path. Hard guards: never reset a vault
+        // that has verified its ceremony or that contains any data.
+        if let Some(vault) = s.vault.lock().unwrap().take() {
+            if verified(&vault)? {
+                *s.vault.lock().unwrap() = Some(vault);
+                return Err("vault is already provisioned and verified".into());
+            }
+            let live = vault.lock().unwrap().item_count().map_err(|e| e.to_string())?;
+            if live > 0 {
+                *s.vault.lock().unwrap() = Some(vault);
+                return Err("refusing to reset: vault contains data".into());
+            }
+            drop(vault); // close the connection before deleting the file
+            svc.reset_for_reprovision().map_err(|e| e.to_string())?;
+            std::fs::remove_file(&s.db_path).map_err(|e| e.to_string())?;
+        } else if s.db_path.exists() || !matches!(svc.state(false), Ok(KeyState::FirstRun)) {
+            return Err("vault is already provisioned; refusing to overwrite".into());
+        }
+
+        let (dek, recovery) = svc.provision().map_err(|e| e.to_string())?;
+        let vault = Vault::open(&s.db_path, &dek).map_err(|e| e.to_string())?;
+        vault
+            .put_meta(META_RECOVERY_VERIFIED, "false")
+            .map_err(|e| e.to_string())?;
+        s.cache_vault(vault);
+        Ok(recovery.display().to_string())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// D8 ceremony verification: the user re-enters the key; success is the
+/// input authenticating the recovery blob. Only then does ingestion start.
+#[tauri::command]
+pub async fn verify_recovery_key(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<AppState>>,
+    input: String,
+) -> Result<(), String> {
+    let s = Arc::clone(&state);
+    let app2 = app.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let svc = s.key_service();
+        svc.verify_recovery(&input).map_err(friendly_key_error)?;
+        let vault = s.cached_vault().ok_or("no vault is being provisioned")?;
+        vault
+            .lock()
+            .unwrap()
+            .put_meta(META_RECOVERY_VERIFIED, "true")
+            .map_err(|e| e.to_string())?;
+        start_pipeline(&app2, &s);
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Keychain-loss path: the recovery key re-establishes the keychain wrapper
+/// and unlocks. Presenting the key IS proof of possession, so the ceremony
+/// flag is set in the same step.
+#[tauri::command]
+pub async fn recover_with_key(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, Arc<AppState>>,
+    input: String,
+) -> Result<(), String> {
+    let s = Arc::clone(&state);
+    let app2 = app.clone();
+    tauri::async_runtime::spawn_blocking(move || {
+        let svc = s.key_service();
+        let dek = svc.recover(&input).map_err(friendly_key_error)?;
+        let vault = Vault::open(&s.db_path, &dek).map_err(|e| e.to_string())?;
+        vault
+            .put_meta(META_RECOVERY_VERIFIED, "true")
+            .map_err(|e| e.to_string())?;
+        s.cache_vault(vault);
+        start_pipeline(&app2, &s);
+        Ok(())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_items(
+    state: tauri::State<'_, Arc<AppState>>,
+    limit: Option<u32>,
+) -> Result<Vec<ItemView>, String> {
+    let s = Arc::clone(&state);
+    tauri::async_runtime::spawn_blocking(move || {
+        let vault = s.cached_vault().ok_or("vault is not unlocked")?;
+        let items = vault
+            .lock()
+            .unwrap()
+            .recent_items(limit.unwrap_or(200))
+            .map_err(|e| e.to_string())?;
+        Ok(items
+            .into_iter()
+            .map(|i| ItemView {
+                id: i.id,
+                connector_id: i.connector_id,
+                source_id: i.source_id,
+                kind: serde_json::to_value(&i.kind).unwrap_or_default(),
+                timestamp: i.timestamp.to_rfc3339(),
+                ingested_at: i.ingested_at.to_rfc3339(),
+                properties: i.properties,
+            })
+            .collect())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command]
+pub async fn get_stats(state: tauri::State<'_, Arc<AppState>>) -> Result<VaultStats, String> {
+    let s = Arc::clone(&state);
+    tauri::async_runtime::spawn_blocking(move || {
+        let vault = s.cached_vault().ok_or("vault is not unlocked")?;
+        let live = vault.lock().unwrap().item_count().map_err(|e| e.to_string())?;
+        Ok(VaultStats {
+            live_items: live,
+            import_dir: s.import_dir.display().to_string(),
+        })
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Key errors phrased for humans, with the deliberate property that wrong
+/// key / tampered blob / format drift all read the same (no oracle).
+fn friendly_key_error(e: KeyError) -> String {
+    match e {
+        KeyError::MalformedRecoveryKey => {
+            "A recovery key is 64 hex characters (dashes and spaces are fine). \
+             Check what you entered."
+                .into()
+        }
+        KeyError::IntegrityFailure => {
+            "That key does not match this vault. Check for typos and try again.".into()
+        }
+        other => other.to_string(),
+    }
+}

--- a/desktop/wkyt/src/app.html
+++ b/desktop/wkyt/src/app.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Tauri + SvelteKit + Typescript App</title>
+    <title>wkyt</title>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/desktop/wkyt/src/routes/+page.svelte
+++ b/desktop/wkyt/src/routes/+page.svelte
@@ -1,216 +1,507 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
+  import { onDestroy, onMount } from "svelte";
 
-  let name = $state("");
-  let greetMsg = $state("");
+  type VaultStatus =
+    | { state: "first_run" }
+    | { state: "ready"; live_items: number }
+    | { state: "keychain_lost" }
+    | { state: "inconsistent"; reason: string };
 
-  async function greet(event: Event) {
-    event.preventDefault();
-    // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-    greetMsg = await invoke("greet", { name });
+  interface ItemView {
+    id: string;
+    connector_id: string;
+    source_id: string;
+    kind: unknown;
+    timestamp: string;
+    ingested_at: string;
+    properties: Record<string, unknown>;
   }
 
-  import { listen } from "@tauri-apps/api/event";
-
-  interface User {
-    name: string;
-    email: string;
-    picture?: string;
+  interface VaultStats {
+    live_items: number;
+    import_dir: string;
   }
 
-  let user = $state<User | null>(null);
-  let oauthState = "";
+  type Phase =
+    | "loading"
+    | "first_run"
+    | "ceremony_show"
+    | "ceremony_verify"
+    | "keychain_lost"
+    | "inconsistent"
+    | "ready"
+    | "fatal";
 
-  async function loginWithGoogle() {
-    try {
-      oauthState = crypto.randomUUID();
-      await invoke("start_oauth", { state: oauthState });
-    } catch (error) {
-      console.error("Failed to start OAuth:", error);
-      alert("Failed to start authentication flow. Please try again later.");
-    }
-  }
+  let phase = $state<Phase>("loading");
+  let fatalMessage = $state("");
+  let inconsistentReason = $state("");
 
-  async function logout() {
-    try {
-      await invoke("logout");
-    } catch (error) {
-      console.error("Logout failed:", error);
-    } finally {
-      user = null;
-    }
-  }
+  // Ceremony state. recoveryKey exists in the UI only between
+  // begin_first_run and verification, then is overwritten.
+  let recoveryKey = $state("");
+  let keyInput = $state("");
+  let keyError = $state("");
+  let copied = $state(false);
+  let busy = $state(false);
 
-  listen("oauth-code", async (event) => {
-    console.log("got oauth-code", event.payload);
-    const { code, state } = event.payload as { code: string; state: string };
+  // Dashboard state.
+  let items = $state<ItemView[]>([]);
+  let stats = $state<VaultStats | null>(null);
+  let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
-    if (state !== oauthState) {
-      console.error("OAuth state mismatch!");
-      alert("Authentication failed: invalid state.");
-      return;
-    }
-
-    try {
-      const token = await invoke<string>("exchange_code_for_token", { code });
-      console.log("got token", token);
-      user = await invoke<User>("get_user_info", { token });
-    } catch (error) {
-      console.error("Authentication failed:", error);
-      alert("Authentication failed. Please check your credentials and try again.");
-    }
+  onMount(refreshStatus);
+  onDestroy(() => {
+    if (refreshTimer) clearInterval(refreshTimer);
   });
+
+  async function refreshStatus() {
+    try {
+      const status = await invoke<VaultStatus>("vault_status");
+      switch (status.state) {
+        case "first_run":
+          phase = "first_run";
+          break;
+        case "ready":
+          enterDashboard();
+          break;
+        case "keychain_lost":
+          phase = "keychain_lost";
+          break;
+        case "inconsistent":
+          inconsistentReason = status.reason;
+          phase = "inconsistent";
+          break;
+      }
+    } catch (e) {
+      fatalMessage = String(e);
+      phase = "fatal";
+    }
+  }
+
+  async function beginFirstRun() {
+    busy = true;
+    keyError = "";
+    try {
+      recoveryKey = await invoke<string>("begin_first_run");
+      copied = false;
+      phase = "ceremony_show";
+    } catch (e) {
+      keyError = String(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function copyKey() {
+    await navigator.clipboard.writeText(recoveryKey);
+    copied = true;
+  }
+
+  function proceedToVerify() {
+    phase = "ceremony_verify";
+    keyInput = "";
+    keyError = "";
+  }
+
+  async function verifyKey() {
+    busy = true;
+    keyError = "";
+    try {
+      await invoke("verify_recovery_key", { input: keyInput });
+      recoveryKey = ""; // gone from the UI for good
+      keyInput = "";
+      enterDashboard();
+    } catch (e) {
+      keyError = String(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function recoverWithKey() {
+    busy = true;
+    keyError = "";
+    try {
+      await invoke("recover_with_key", { input: keyInput });
+      keyInput = "";
+      enterDashboard();
+    } catch (e) {
+      keyError = String(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  function enterDashboard() {
+    phase = "ready";
+    loadData();
+    if (!refreshTimer) refreshTimer = setInterval(loadData, 5000);
+  }
+
+  async function loadData() {
+    try {
+      stats = await invoke<VaultStats>("get_stats");
+      items = await invoke<ItemView[]>("get_items", { limit: 200 });
+    } catch (e) {
+      console.error("dashboard refresh failed:", e);
+    }
+  }
+
+  function kindLabel(kind: unknown): string {
+    if (typeof kind === "string") return kind;
+    if (kind && typeof kind === "object") {
+      const k = kind as Record<string, string>;
+      if ("other" in k) return k.other;
+    }
+    return String(kind);
+  }
+
+  function propsPreview(p: Record<string, unknown>): string {
+    const json = JSON.stringify(p);
+    return json.length > 120 ? json.slice(0, 117) + "…" : json;
+  }
+
+  function fmtTime(iso: string): string {
+    return new Date(iso).toLocaleString();
+  }
 </script>
 
 <main class="container">
-  <h1>Welcome to Tauri + Svelte</h1>
+  {#if phase === "loading"}
+    <p class="muted">Unlocking vault…</p>
+  {:else if phase === "first_run"}
+    <section class="card">
+      <h1>Welcome to wkyt</h1>
+      <p>
+        Your data vault is encrypted on this device. Before anything is
+        ingested, you'll get a <strong>recovery key</strong> — the only way
+        back in if this machine's keychain is ever lost.
+      </p>
+      <button onclick={beginFirstRun} disabled={busy}>Create my vault</button>
+      {#if keyError}<p class="error">{keyError}</p>{/if}
+    </section>
+  {:else if phase === "ceremony_show"}
+    <section class="card">
+      <h1>Your recovery key</h1>
+      <p>
+        Write this down or store it in a password manager.
+        <strong>It will never be shown again.</strong> Without it, losing
+        this machine's keychain means losing your data.
+      </p>
+      <code class="recovery-key">{recoveryKey}</code>
+      <div class="row">
+        <button onclick={copyKey}>{copied ? "Copied ✓" : "Copy"}</button>
+        <button class="primary" onclick={proceedToVerify}>
+          I saved it — verify me
+        </button>
+      </div>
+    </section>
+  {:else if phase === "ceremony_verify"}
+    <section class="card">
+      <h1>Verify your recovery key</h1>
+      <p>
+        Enter the key you just saved. This proves the copy you kept actually
+        works — the screen showing it is gone.
+      </p>
+      <input
+        class="key-input"
+        placeholder="XXXX-XXXX-…"
+        bind:value={keyInput}
+        autocomplete="off"
+        spellcheck="false"
+      />
+      <div class="row">
+        <button onclick={verifyKey} disabled={busy || keyInput.trim() === ""}>
+          Verify and open vault
+        </button>
+      </div>
+      {#if keyError}<p class="error">{keyError}</p>{/if}
+    </section>
+  {:else if phase === "keychain_lost"}
+    <section class="card">
+      <h1>Keychain lost</h1>
+      <p>
+        This vault exists, but the OS keychain no longer holds its key
+        (reinstalled OS? new keyring?). Enter your recovery key to restore
+        access — your data is intact.
+      </p>
+      <input
+        class="key-input"
+        placeholder="XXXX-XXXX-…"
+        bind:value={keyInput}
+        autocomplete="off"
+        spellcheck="false"
+      />
+      <div class="row">
+        <button onclick={recoverWithKey} disabled={busy || keyInput.trim() === ""}>
+          Recover vault
+        </button>
+      </div>
+      {#if keyError}<p class="error">{keyError}</p>{/if}
+    </section>
+  {:else if phase === "inconsistent"}
+    <section class="card">
+      <h1>Vault needs attention</h1>
+      <p class="error">{inconsistentReason}</p>
+      <p class="muted">
+        The vault file and its key material disagree. This needs manual
+        intervention — nothing has been changed.
+      </p>
+    </section>
+  {:else if phase === "fatal"}
+    <section class="card">
+      <h1>Something went wrong</h1>
+      <p class="error">{fatalMessage}</p>
+      <button onclick={refreshStatus}>Retry</button>
+    </section>
+  {:else if phase === "ready"}
+    <header class="topbar">
+      <h1>wkyt vault</h1>
+      <div class="stats">
+        <span><strong>{stats?.live_items ?? "…"}</strong> items</span>
+        <button class="small" onclick={loadData}>Refresh</button>
+      </div>
+    </header>
+    <p class="muted import-hint">
+      Drop <code>.json</code> / <code>.ics</code> files into
+      <code>{stats?.import_dir ?? "…"}</code> — they are picked up within ~10s.
+    </p>
 
-  <div class="row">
-    <a href="https://vitejs.dev" target="_blank">
-      <img src="/vite.svg" class="logo vite" alt="Vite Logo" />
-    </a>
-    <a href="https://tauri.app" target="_blank">
-      <img src="/tauri.svg" class="logo tauri" alt="Tauri Logo" />
-    </a>
-    <a href="https://kit.svelte.dev" target="_blank">
-      <img src="/svelte.svg" class="logo svelte-kit" alt="SvelteKit Logo" />
-    </a>
-  </div>
-  <p>Click on the Tauri, Vite, and SvelteKit logos to learn more.</p>
-
-  {#if user}
-    <p>Welcome, {user.name} ({user.email})</p>
-    <button onclick={logout}>Logout</button>
-  {:else}
-    <form class="row" onsubmit={greet}>
-      <input id="greet-input" placeholder="Enter a name..." bind:value={name} />
-      <button type="submit">Greet</button>
-    </form>
-    <p>{greetMsg}</p>
-
-    <div class="row">
-      <button onclick={loginWithGoogle}>Login with Google</button>
-    </div>
+    {#if items.length === 0}
+      <p class="muted empty">The vault is empty so far.</p>
+    {:else}
+      <table>
+        <thead>
+          <tr>
+            <th>When</th>
+            <th>Connector</th>
+            <th>Source</th>
+            <th>Kind</th>
+            <th>Properties</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each items as item (item.id)}
+            <tr>
+              <td class="nowrap">{fmtTime(item.timestamp)}</td>
+              <td>{item.connector_id}</td>
+              <td>{item.source_id}</td>
+              <td><span class="kind">{kindLabel(item.kind)}</span></td>
+              <td class="props">{propsPreview(item.properties)}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
   {/if}
 </main>
 
 <style>
-.logo.vite:hover {
-  filter: drop-shadow(0 0 2em #747bff);
-}
-
-.logo.svelte-kit:hover {
-  filter: drop-shadow(0 0 2em #ff3e00);
-}
-
-:root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-
-  color: #0f0f0f;
-  background-color: #f6f6f6;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
-}
-
-.container {
-  margin: 0;
-  padding-top: 10vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: 0.75s;
-}
-
-.logo.tauri:hover {
-  filter: drop-shadow(0 0 2em #24c8db);
-}
-
-.row {
-  display: flex;
-  justify-content: center;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-
-a:hover {
-  color: #535bf2;
-}
-
-h1 {
-  text-align: center;
-}
-
-input,
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
-  transition: border-color 0.25s;
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
-}
-
-button {
-  cursor: pointer;
-}
-
-button:hover {
-  border-color: #396cd8;
-}
-button:active {
-  border-color: #396cd8;
-  background-color: #e8e8e8;
-}
-
-input,
-button {
-  outline: none;
-}
-
-#greet-input {
-  margin-right: 5px;
-}
-
-@media (prefers-color-scheme: dark) {
   :root {
-    color: #f6f6f6;
-    background-color: #2f2f2f;
+    font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.5;
+    color: #0f0f0f;
+    background-color: #f6f6f6;
   }
 
-  a:hover {
-    color: #24c8db;
+  .container {
+    max-width: 920px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
   }
 
-  input,
+  .card {
+    max-width: 560px;
+    margin: 12vh auto 0;
+    padding: 2rem;
+    background: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  }
+
+  .card h1 {
+    margin-top: 0;
+    font-size: 1.4rem;
+  }
+
+  .recovery-key {
+    display: block;
+    margin: 1.2rem 0;
+    padding: 1rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.95rem;
+    word-break: break-all;
+    background: #f0f0f0;
+    border-radius: 8px;
+    user-select: all;
+  }
+
+  .key-input {
+    width: 100%;
+    box-sizing: border-box;
+    margin: 0.8rem 0;
+    padding: 0.7em 0.9em;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    border-radius: 8px;
+    border: 1px solid #ccc;
+  }
+
+  .row {
+    display: flex;
+    gap: 0.6rem;
+    margin-top: 0.6rem;
+  }
+
   button {
-    color: #ffffff;
-    background-color: #0f0f0f98;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    padding: 0.55em 1.1em;
+    font-size: 0.95em;
+    font-weight: 500;
+    font-family: inherit;
+    color: #0f0f0f;
+    background-color: #ffffff;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
+    cursor: pointer;
+    transition: border-color 0.2s;
   }
-  button:active {
-    background-color: #0f0f0f69;
-  }
-}
 
+  button:hover {
+    border-color: #396cd8;
+  }
+
+  button:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  button.primary {
+    background: #396cd8;
+    color: #fff;
+  }
+
+  button.small {
+    padding: 0.3em 0.8em;
+    font-size: 0.85em;
+  }
+
+  .topbar {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+  }
+
+  .topbar h1 {
+    font-size: 1.3rem;
+    margin: 0;
+  }
+
+  .stats {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+  }
+
+  .import-hint {
+    margin-top: 0.2rem;
+  }
+
+  .import-hint code {
+    background: #ececec;
+    padding: 0.1em 0.4em;
+    border-radius: 4px;
+  }
+
+  table {
+    width: 100%;
+    margin-top: 1rem;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+  }
+
+  th {
+    text-align: left;
+    padding: 0.5rem 0.6rem;
+    border-bottom: 2px solid #ddd;
+    font-weight: 600;
+  }
+
+  td {
+    padding: 0.45rem 0.6rem;
+    border-bottom: 1px solid #e8e8e8;
+    vertical-align: top;
+  }
+
+  .nowrap {
+    white-space: nowrap;
+  }
+
+  .kind {
+    background: #e6efff;
+    color: #2a55b0;
+    padding: 0.1em 0.5em;
+    border-radius: 999px;
+    font-size: 0.8rem;
+  }
+
+  .props {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.78rem;
+    color: #555;
+    word-break: break-all;
+  }
+
+  .muted {
+    color: #777;
+  }
+
+  .empty {
+    text-align: center;
+    margin-top: 3rem;
+  }
+
+  .error {
+    color: #c43c3c;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      color: #f6f6f6;
+      background-color: #1f1f1f;
+    }
+    .card {
+      background: #2a2a2a;
+      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
+    }
+    .recovery-key {
+      background: #1a1a1a;
+    }
+    .key-input {
+      background: #1a1a1a;
+      color: #f6f6f6;
+      border-color: #444;
+    }
+    button {
+      color: #f6f6f6;
+      background-color: #0f0f0f98;
+    }
+    .import-hint code {
+      background: #333;
+    }
+    th {
+      border-bottom-color: #444;
+    }
+    td {
+      border-bottom-color: #333;
+    }
+    .kind {
+      background: #25355c;
+      color: #9db9f5;
+    }
+    .props {
+      color: #aaa;
+    }
+  }
 </style>


### PR DESCRIPTION
…irst-run flow

Backend (vault_commands.rs): frontend-driven state machine. vault_status performs the silent keychain unlock and reports
first_run/ready/keychain_lost/inconsistent; begin_first_run provisions and returns the recovery key — the only moment it ever crosses to the UI; verify_recovery_key implements the amended-D8 re-entry check (authenticates against the recovery blob, not string comparison) and only THEN starts the ingestion pipeline; recover_with_key handles keychain loss. Viewer queries: get_items (raw_payload deliberately excluded) + get_stats. All vault/keychain work on spawn_blocking.

Abandoned-ceremony safety: ingestion gates on a recovery_verified flag in vault_meta, so a vault whose ceremony never verified is provably empty; begin_first_run then resets key material and re-provisions — hard-guarded against verified or non-empty vaults. New KeyService::reset_for_reprovision (narrow, documented, tested) and Vault::recent_items support this and the viewer.

Frontend: boilerplate (greet/logos/mock-login) removed. Single-page phase machine: first-run welcome -> recovery key display (copy + explicit 'never shown again' warning) -> forced re-entry verification -> dashboard; keychain-lost recovery screen; dashboard lists vault items (time/connector/source/kind/properties preview) with 5s auto-refresh and shows the import-folder path. Spec DoD #7 satisfied.

57 Rust tests green; svelte-check 0 errors; vite build clean.

https://claude.ai/code/session_014HNypS7m7m4ho8DKJriNk6