### PR TITLE
docs: bring README and Roadmap up to date with Phase 1 status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,104 @@
 # WackyTheorem : Promptware
 [![Tauri CI](https://github.com/redog/WackyTheorem/actions/workflows/ci.yml/badge.svg)](https://github.com/redog/WackyTheorem/actions/workflows/ci.yml)
 
-An unconventional app done with a complete lack of seriousness. 
+An unconventional app done with a complete lack of seriousness.
 
-Built with Tauri and Svelte, designed to be a personal data assistant. This project is in its early stages and aims to provide a secure, on-device way to interact with your personal data.
-
+Built with Tauri and Svelte, designed to be a personal data assistant. Data is
+ingested from local sources (and soon Google), encrypted on-device with
+sqlcipher, and browsable in a minimal dashboard. Architectural decisions are
+recorded in [`DECISIONS.md`](DECISIONS.md); the phase plan lives in
+[`Roadmap.md`](Roadmap.md).
 
 ## Implementation Status
 
-The project is currently in **Phase 1: Core Infrastructure & Unified Data Vault**.
+The project is in **Phase 1: Core Infrastructure & Unified Data Vault**.
+The ingestion pipeline is complete end to end; Google OAuth + Calendar
+ingestion is the remaining Phase 1 work.
 
-The main goal of this phase is to establish the foundational data layer. This involves securely ingesting, encrypting, and storing data from multiple sources directly on the user's device.
+**What works today:**
 
-**What has been implemented:**
+*   **Encrypted vault** (`wkyt-vault`): SQLite + sqlcipher (compiled from
+    source, no system deps), KEK/DEK key hierarchy anchored to the OS
+    keychain, recovery-key wrapper, crash-safe DEK rotation via
+    `PRAGMA rekey`. Nothing lands on disk in plaintext — including SQLite
+    temp storage.
+*   **First-run recovery ceremony**: the app displays a one-time recovery
+    key and forces re-entry verification before any data is ingested
+    (D8). Keychain loss is recoverable in-app with that key.
+*   **Connector contract** (`wkyt-core`): streaming, batched
+    `sync(cursor)` with opaque connector-defined sync tokens, an error
+    taxonomy (retryable / auth-required / resync-required / fatal),
+    tombstones for deletions, and deterministic UUIDv5 item identity so
+    re-ingestion is idempotent (D13). Protobuf wire format for batches.
+*   **Pipeline** (`wkyt-broker` + `wkyt-host`): bounded in-process bus
+    with backpressure; the orchestrator applies each batch and its cursor
+    in one vault transaction and acks only after commit. Crash mid-batch
+    resumes from the last committed cursor without duplicates.
+*   **File importer** (`wkyt-connector-file`): watches an `import/`
+    folder for `.json`/`.ics` files; modifications update in place,
+    deletions tombstone, copied-in files with old mtimes are still caught.
+*   **Viewer**: a Svelte dashboard listing vault items with auto-refresh
+    (Spec DoD #7).
+*   **CI**: build + full test suite on Linux, build on macOS/Windows.
 
-*   A desktop application shell using Tauri (Rust backend) and Svelte (frontend).
-*   A partially implemented Google OAuth flow on the backend. This includes the ability to initiate the OAuth process and exchange an authorization code for an access token.
+**What is missing (rest of Phase 1):**
 
-**What is missing:**
+*   A real Google OAuth flow. The current backend commands are debug-mode
+    mocks. The production flow will use OAuth 2.0 with PKCE (D5) — a
+    `client_id` is required, but **no client secret**: PKCE replaces it,
+    and the Spec forbids storing client secrets in the binary. Tokens
+    will be stored in the OS keychain (D3).
+*   Google Calendar ingestion (D4) as the second connector.
+*   Headless-Linux fallback for machines without a Secret Service
+    (passphrase + Argon2id per D2).
 
-*   A real Google OAuth flow. The current backend is a debug-mode mock. The
-    production flow will use OAuth 2.0 with PKCE (see `DECISIONS.md` D5) —
-    a `client_id` is required, but **no client secret**: PKCE replaces it,
-    and the Spec forbids storing client secrets in the binary.
-*   Secure storage of the access token (OS keychain via `keyring`, per D3).
-*   Data ingestion from Google services.
-*   Connections to other data sources.
-*   An encrypted local database.
-*   A user interface for managing data sources and viewing ingested data.
+## Architecture
+
+```
+crates/
+  wkyt-core            domain types, Connector trait, delta wire format
+  wkyt-vault           encrypted vault: keys, schema, atomic batch-apply
+  wkyt-broker          Bus trait + bounded in-process transport
+  wkyt-connector-file  file-importer connector
+  wkyt-host            orchestrator: connector -> bus -> vault, ack-after-commit
+desktop/wkyt           Tauri app (Rust backend + Svelte frontend)
+```
 
 ## How to Build and Run
 
-To build and run this project, you will need to have Node.js and Rust installed, along with the Tauri prerequisites.
+Prerequisites: [Node.js](https://nodejs.org/en/),
+[Rust](https://www.rust-lang.org/tools/install), and the
+[Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for your
+platform. No other system libraries are required — sqlcipher and its
+OpenSSL are compiled from source.
 
-### Prerequisites
+```bash
+git clone https://github.com/redog/WackyTheorem.git
+cd WackyTheorem/desktop/wkyt
+npm install
+npm run tauri dev
+```
 
-*   [Node.js](https://nodejs.org/en/)
-*   [Rust](https://www.rust-lang.org/tools/install)
-*   [Tauri Prerequisites](https://tauri.app/v1/guides/getting-started/prerequisites)
-
-### Steps
-
-1.  **Clone the repository:**
-    ```bash
-    git clone https://github.com/redog/WackyTheorem.git
-    cd WackyTheorem/desktop/wkyt
-    ```
-
-2.  **Install frontend dependencies:**
-    ```bash
-    npm install
-    ```
-
-3.  **Run the application in development mode:**
-    ```bash
-    npm run tauri dev
-    ```
+On first launch the app walks you through the recovery-key ceremony, then
+shows the dashboard. Drop `.json` or `.ics` files into the `import/`
+folder it displays (inside the app data directory) — they are ingested
+into the encrypted vault within ~10 seconds.
 
 ## How to Test
 
-Backend unit tests live in `desktop/wkyt/src-tauri/src` and run with
-`cargo test` from `desktop/wkyt/src-tauri`. End-to-end behavior is still
-verified manually by running the application.
+```bash
+cargo test --workspace        # from the repo root; 57 tests
+cd desktop/wkyt && npm run check   # frontend type-check
+```
+
+Coverage includes the crypto lifecycle (provision / unlock / recovery /
+rotation, tamper and blob-swap rejection), crash-recovery replay without
+duplicates, and an end-to-end file → bus → encrypted-vault pipeline.
 
 ## Configuration
 
-Google authentication uses OAuth 2.0 with PKCE (RFC 7636) — see
-`DECISIONS.md` D5. You will need to supply your own Google OAuth
+Google authentication (upcoming) uses OAuth 2.0 with PKCE (RFC 7636) —
+see `DECISIONS.md` D5. You will need to supply your own Google OAuth
 `client_id` (a "Desktop app" credential from the Google Cloud Console).
 **Do not** create or embed a client secret: PKCE replaces it for native
 apps, and the Spec forbids client secrets in the binary. Tokens are never

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,10 +1,37 @@
-# Phase 1: Core Infrastructure & Unified Data Vault
+# Phase 1: Core Infrastructure & Unified Data Vault — IN PROGRESS
 
 Objective: Establish the foundational data layer. The primary goal is to securely ingest, encrypt, and store data from multiple sources directly on the user's device.
 
-Key Outcomes: A desktop application that can connect to at least two data sources (e.g., Google and a browser plugin), pull data, and store it in an encrypted local database.
+Key Outcomes: A desktop application that can connect to at least two data sources, pull data, and store it in an encrypted local database.
 
-Milestone for Phase 1: Successfully connect to a Google account and a browser, ingest data from both, and view the encrypted, normalized data within the basic desktop app UI.
+Milestone for Phase 1: Successfully connect to a Google account and a local data source, ingest data from both, and view the encrypted, normalized data within the basic desktop app UI.
+
+> **Scope note (D4):** the Spec puts the browser plugin out of scope for
+> Phase 1; the second local source is the file importer, and the browser
+> plugin moves to Phase 2. This document previously disagreed with the
+> Spec on that point — the Spec wins.
+
+## Status (2026-06-11)
+
+Done:
+- [x] Cargo workspace: `wkyt-core`, `wkyt-vault`, `wkyt-broker`, `wkyt-connector-file`, `wkyt-host` + Tauri app (M1)
+- [x] Encrypted vault: sqlcipher, KEK/DEK keychain hierarchy, recovery-key ceremony with forced verification, crash-safe DEK rotation (M2, D8/D12)
+- [x] Connector contract: streaming batches, opaque cursors, error taxonomy, tombstones, deterministic UUIDv5 identity (D13)
+- [x] Pipeline: bounded in-process bus (D11), transactional batch+cursor apply, ack-after-commit, crash-replay without duplicates (M3)
+- [x] File-importer connector + import-folder watcher (M4)
+- [x] Viewer dashboard (Spec DoD #7) and first-run ceremony UI
+- [x] CI green on Linux/macOS/Windows, `cargo test` enforced (Spec DoD #8)
+
+Remaining for Phase 1:
+- [ ] Google OAuth 2.0 PKCE flow, tokens in OS keychain (D3/D5 — Spec DoD #2–4)
+- [ ] Google Calendar connector, ≥30 days of events (D4 — Spec DoD #5)
+- [ ] Headless-Linux keyring fallback: passphrase + Argon2id (D2)
+
+Open questions for operator:
+- WASM connector sandboxing (the M5 host) is designed but unscheduled —
+  fold into late Phase 1 or defer to Phase 2 alongside the browser plugin?
+- The recovery ceremony currently offers copy-to-clipboard only; D8 also
+  suggested a downloadable `.txt`. Worth the extra surface?
 
 # Phase 2: Personal LLM & Temporal Graph
 


### PR DESCRIPTION
README: current architecture (workspace crates), what works (encrypted vault + ceremony, pipeline, file importer, viewer, CI) vs what remains (Google PKCE + Calendar, headless keyring fallback), accurate build/test instructions.

Roadmap: Phase 1 status checklist (done vs remaining mapped to Spec DoD items), records the D4 scope correction (browser plugin is Phase 2 per Spec), and two open questions for operator (WASM host scheduling, recovery-key .txt download).

https://claude.ai/code/session_014HNypS7m7m4ho8DKJriNk6