### PR TITLE
feat: Google OAuth PKCE + Calendar connector (D3-D6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +304,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +509,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -649,7 +684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -743,7 +778,15 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
  "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
  "zeroize",
 ]
 
@@ -786,6 +829,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1335,8 +1379,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1346,9 +1392,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1576,6 +1624,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1708,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1854,6 +1936,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -2017,6 +2100,7 @@ dependencies = [
  "byteorder",
  "dbus-secret-service",
  "log",
+ "secret-service",
  "security-framework 2.11.1",
  "security-framework 3.7.0",
  "windows-sys 0.60.2",
@@ -2166,6 +2250,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,10 +2388,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2332,6 +2499,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -2823,6 +3010,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3002,6 +3198,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,12 +3274,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3108,6 +3409,44 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -3138,6 +3477,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3183,10 +3536,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3253,6 +3647,25 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2",
+ "zbus 4.4.0",
+]
 
 [[package]]
 name = "security-framework"
@@ -3386,6 +3799,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,6 +3836,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3475,6 +3911,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3597,6 +4044,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -3786,7 +4239,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3904,7 +4357,7 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows",
- "zbus",
+ "zbus 5.16.0",
 ]
 
 [[package]]
@@ -4150,6 +4603,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4488,6 +4951,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4499,6 +4968,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -4731,6 +5206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4784,6 +5269,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5014,6 +5508,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5382,13 +5885,16 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures-util",
+ "open",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
  "tokio",
+ "tracing",
  "wkyt-connector-file",
+ "wkyt-connector-google",
  "wkyt-core",
  "wkyt-host",
  "wkyt-vault",
@@ -5415,6 +5921,27 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "wkyt-core",
+]
+
+[[package]]
+name = "wkyt-connector-google"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures-core",
+ "futures-util",
+ "keyring",
+ "oauth2",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+ "urlencoding",
  "wkyt-core",
 ]
 
@@ -5538,6 +6065,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5558,6 +6095,38 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -5590,9 +6159,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 1.0.3",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.16.0",
+ "zbus_names 4.3.2",
+ "zvariant 5.12.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -5605,9 +6187,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.2",
+ "zvariant 5.12.0",
+ "zvariant_utils 3.4.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -5618,7 +6211,7 @@ checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
  "winnow 1.0.3",
- "zvariant",
+ "zvariant 5.12.0",
 ]
 
 [[package]]
@@ -5723,6 +6316,19 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
@@ -5731,8 +6337,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 1.0.3",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.12.0",
+ "zvariant_utils 3.4.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -5745,7 +6364,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zvariant_utils",
+ "zvariant_utils 3.4.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/wkyt-vault",
     "crates/wkyt-broker",
     "crates/wkyt-connector-file",
+    "crates/wkyt-connector-google",
     "crates/wkyt-host",
     "desktop/wkyt/src-tauri",
 ]
@@ -24,6 +25,7 @@ wkyt-core = { path = "crates/wkyt-core" }
 wkyt-vault = { path = "crates/wkyt-vault" }
 wkyt-broker = { path = "crates/wkyt-broker" }
 wkyt-connector-file = { path = "crates/wkyt-connector-file" }
+wkyt-connector-google = { path = "crates/wkyt-connector-google" }
 wkyt-host = { path = "crates/wkyt-host" }
 
 # Async runtime primitives. default-features = false: each crate enables

--- a/crates/wkyt-connector-google/Cargo.toml
+++ b/crates/wkyt-connector-google/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "wkyt-connector-google"
+description = "Google Calendar connector: OAuth 2.0 PKCE + Calendar API ingestion (D3–D6)"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+
+[dependencies]
+# Domain types: Item, Connector trait, error taxonomy, delta wire format.
+wkyt-core = { workspace = true }
+
+# Async runtime (spawn_blocking for the localhost listener, sleep for
+# retry backoff, oneshot for auth completion signaling).
+tokio = { workspace = true, features = ["rt", "sync", "net", "macros", "time"] }
+
+# OAuth 2.0 PKCE flow (D5). reqwest integration for the token exchange.
+oauth2 = "5"
+
+# HTTP client for Calendar API calls and OAuth token exchange (D6).
+# rustls-tls: no system OpenSSL dependency, consistent with D1 amendment.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+# Token (de)serialization and Calendar API response parsing.
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Event timestamps from Calendar API responses.
+chrono = { workspace = true }
+
+# Connector trait requires async_trait for dyn dispatch.
+async-trait = { workspace = true }
+
+# Stream construction for the DeltaStream return type.
+futures-util = { workspace = true }
+futures-core = { workspace = true }
+
+# OS keychain for token persistence (D3). Same backend as the vault key (D2).
+keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
+
+# URL parsing for OAuth endpoints.
+url = "2"
+# Percent-encoding for query parameters in Calendar API URLs.
+urlencoding = "2"
+
+# Logging diagnostics during auth flow and API calls.
+tracing = "0.1"
+
+# PKCE verifier is generated from random bytes; also used for OAuth state.
+rand = "0.9"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/wkyt-connector-google/src/auth.rs
+++ b/crates/wkyt-connector-google/src/auth.rs
@@ -1,0 +1,366 @@
+//! OAuth 2.0 PKCE flow for Google (D5).
+//!
+//! Architecture: the auth module handles token acquisition and refresh but
+//! does NOT own the Connector trait. The [`GoogleCalendarConnector`] calls
+//! into this module to get a valid access token before making API requests.
+//!
+//! Token lifecycle:
+//! 1. No tokens → `AuthRequired` error surfaces to the orchestrator/UI.
+//! 2. UI calls [`PkceFlow::start`] → opens browser, catches redirect,
+//!    exchanges code for tokens, stores in keyring.
+//! 3. Connector calls [`TokenStore::access_token`] → returns cached token
+//!    or silently refreshes using the refresh token.
+//! 4. Refresh fails (revoked, expired) → `AuthRequired` again.
+
+use keyring::Entry;
+use oauth2::basic::BasicClient;
+use oauth2::{
+    AuthUrl, AuthorizationCode, ClientId, CsrfToken, EndpointSet, PkceCodeChallenge,
+    PkceCodeVerifier, RedirectUrl, Scope, TokenResponse, TokenUrl,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
+
+const GOOGLE_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+
+/// Calendar read-only scope — the minimum we need for Phase 1.
+const CALENDAR_SCOPE: &str = "https://www.googleapis.com/auth/calendar.readonly";
+
+/// Keyring service name for WackyTheorem OAuth tokens.
+const KEYRING_SERVICE: &str = "wkyt-google-oauth";
+const KEYRING_USER: &str = "tokens";
+
+/// Serialized token bundle stored in the OS keychain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoredTokens {
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+    /// Unix timestamp (seconds) when access_token expires.
+    pub expires_at: Option<i64>,
+}
+
+impl StoredTokens {
+    /// Conservative: treat tokens expiring within 60s as expired.
+    pub fn is_expired(&self) -> bool {
+        match self.expires_at {
+            Some(exp) => chrono::Utc::now().timestamp() >= (exp - 60),
+            None => true, // no expiry info → assume expired, force refresh
+        }
+    }
+}
+
+/// Manages token persistence in the OS keychain and in-memory caching.
+pub struct TokenStore {
+    client_id: String,
+    cached: Arc<RwLock<Option<StoredTokens>>>,
+}
+
+impl TokenStore {
+    pub fn new(client_id: impl Into<String>) -> Self {
+        Self {
+            client_id: client_id.into(),
+            cached: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Load tokens from keyring into cache. Call once at startup.
+    pub fn load_from_keyring(&self) -> Result<bool, String> {
+        let entry = Entry::new(KEYRING_SERVICE, KEYRING_USER)
+            .map_err(|e| format!("keyring entry error: {e}"))?;
+        match entry.get_password() {
+            Ok(json) => {
+                let tokens: StoredTokens = serde_json::from_str(&json)
+                    .map_err(|e| format!("corrupt token JSON in keyring: {e}"))?;
+                let mut guard = self.cached.blocking_write();
+                *guard = Some(tokens);
+                Ok(true)
+            }
+            Err(keyring::Error::NoEntry) => Ok(false),
+            Err(e) => Err(format!("keyring read error: {e}")),
+        }
+    }
+
+    /// Persist tokens to keyring and update cache.
+    pub async fn store(&self, tokens: StoredTokens) -> Result<(), String> {
+        let json = serde_json::to_string(&tokens)
+            .map_err(|e| format!("token serialization error: {e}"))?;
+
+        // keyring operations are blocking; run off the async runtime.
+        let json_clone = json.clone();
+        tokio::task::spawn_blocking(move || {
+            let entry = Entry::new(KEYRING_SERVICE, KEYRING_USER)
+                .map_err(|e| format!("keyring entry error: {e}"))?;
+            entry
+                .set_password(&json_clone)
+                .map_err(|e| format!("keyring write error: {e}"))
+        })
+        .await
+        .map_err(|e| format!("spawn_blocking join error: {e}"))??;
+
+        let mut guard = self.cached.write().await;
+        *guard = Some(tokens);
+        Ok(())
+    }
+
+    /// Get a valid access token. Refreshes silently if expired.
+    /// Returns `None` if no tokens exist (user must authenticate).
+    pub async fn access_token(&self) -> Result<Option<String>, String> {
+        let guard = self.cached.read().await;
+        let tokens = match guard.as_ref() {
+            Some(t) => t.clone(),
+            None => return Ok(None),
+        };
+        drop(guard);
+
+        if !tokens.is_expired() {
+            return Ok(Some(tokens.access_token.clone()));
+        }
+
+        // Try refresh
+        let refresh_token = match &tokens.refresh_token {
+            Some(rt) => rt.clone(),
+            None => {
+                warn!("access token expired and no refresh token available");
+                return Ok(None);
+            }
+        };
+
+        debug!("access token expired, attempting refresh");
+        match self.refresh(&refresh_token).await {
+            Ok(new_tokens) => {
+                let access = new_tokens.access_token.clone();
+                self.store(new_tokens).await?;
+                Ok(Some(access))
+            }
+            Err(e) => {
+                warn!("token refresh failed: {e}");
+                // Clear stale tokens so the next call surfaces AuthRequired
+                let mut guard = self.cached.write().await;
+                *guard = None;
+                Ok(None)
+            }
+        }
+    }
+
+    /// Clear stored tokens (logout).
+    pub async fn clear(&self) -> Result<(), String> {
+        tokio::task::spawn_blocking(|| {
+            if let Ok(entry) = Entry::new(KEYRING_SERVICE, KEYRING_USER) {
+                let _ = entry.delete_credential();
+            }
+        })
+        .await
+        .map_err(|e| format!("spawn_blocking join error: {e}"))?;
+
+        let mut guard = self.cached.write().await;
+        *guard = None;
+        Ok(())
+    }
+
+    /// Refresh access token using the refresh token grant.
+    async fn refresh(&self, refresh_token: &str) -> Result<StoredTokens, String> {
+        let client = build_oauth_client(&self.client_id)?;
+        let http_client = reqwest::Client::new();
+
+        let token_result = client
+            .exchange_refresh_token(&oauth2::RefreshToken::new(refresh_token.to_string()))
+            .request_async(&http_client)
+            .await
+            .map_err(|e| format!("token refresh request failed: {e}"))?;
+
+        let expires_at = token_result
+            .expires_in()
+            .map(|d| chrono::Utc::now().timestamp() + d.as_secs() as i64);
+
+        Ok(StoredTokens {
+            access_token: token_result.access_token().secret().to_string(),
+            refresh_token: token_result
+                .refresh_token()
+                .map(|rt| rt.secret().to_string())
+                .or_else(|| Some(refresh_token.to_string())), // Google doesn't always return a new one
+            expires_at,
+        })
+    }
+}
+
+/// The PKCE authorization flow. Stateful: holds the verifier between
+/// `authorize_url()` and `exchange()`.
+pub struct PkceFlow {
+    client_id: String,
+    pkce_verifier: Option<PkceCodeVerifier>,
+    csrf_token: Option<CsrfToken>,
+    redirect_port: u16,
+}
+
+impl PkceFlow {
+    /// Prepare a new PKCE flow. Does not start the listener yet.
+    pub fn new(client_id: &str, redirect_port: u16) -> Self {
+        Self {
+            client_id: client_id.to_string(),
+            pkce_verifier: None,
+            csrf_token: None,
+            redirect_port,
+        }
+    }
+
+    /// Generate the authorization URL. The caller should open this in the
+    /// user's default browser.
+    pub fn authorize_url(&mut self) -> Result<String, String> {
+        let client = build_oauth_client(&self.client_id)?
+            .set_redirect_uri(
+                RedirectUrl::new(format!("http://localhost:{}/callback", self.redirect_port))
+                    .map_err(|e| format!("invalid redirect URL: {e}"))?,
+            );
+
+        let (challenge, verifier) = PkceCodeChallenge::new_random_sha256();
+
+        let (auth_url, csrf_token) = client
+            .authorize_url(CsrfToken::new_random)
+            .add_scope(Scope::new(CALENDAR_SCOPE.to_string()))
+            .add_extra_param("access_type", "offline") // get refresh token
+            .add_extra_param("prompt", "consent") // force consent to ensure refresh token
+            .set_pkce_challenge(challenge)
+            .url();
+
+        self.pkce_verifier = Some(verifier);
+        self.csrf_token = Some(csrf_token);
+
+        Ok(auth_url.to_string())
+    }
+
+    /// Start a localhost listener, wait for the redirect callback, and
+    /// exchange the authorization code for tokens.
+    ///
+    /// Returns the stored tokens on success. The caller is responsible for
+    /// persisting them via [`TokenStore::store`].
+    pub async fn wait_for_callback_and_exchange(&mut self) -> Result<StoredTokens, String> {
+        let verifier = self
+            .pkce_verifier
+            .take()
+            .ok_or("authorize_url() must be called before exchange")?;
+        let expected_state = self
+            .csrf_token
+            .take()
+            .ok_or("authorize_url() must be called before exchange")?;
+
+        // Bind the localhost listener
+        let listener = tokio::net::TcpListener::bind(format!("127.0.0.1:{}", self.redirect_port))
+            .await
+            .map_err(|e| format!("failed to bind localhost:{}: {e}", self.redirect_port))?;
+
+        info!("listening for OAuth callback on localhost:{}", self.redirect_port);
+
+        // Accept one connection
+        let (stream, _) = listener
+            .accept()
+            .await
+            .map_err(|e| format!("failed to accept connection: {e}"))?;
+
+        // Read the HTTP request
+        let mut buf = vec![0u8; 4096];
+        stream.readable().await.map_err(|e| format!("stream not readable: {e}"))?;
+        let n = stream.try_read(&mut buf).map_err(|e| format!("read error: {e}"))?;
+        let request = String::from_utf8_lossy(&buf[..n]);
+
+        // Parse the GET request line for query parameters
+        let request_line = request
+            .lines()
+            .next()
+            .ok_or("empty HTTP request")?;
+
+        let path = request_line
+            .split_whitespace()
+            .nth(1)
+            .ok_or("malformed HTTP request line")?;
+
+        let url = url::Url::parse(&format!("http://localhost{path}"))
+            .map_err(|e| format!("failed to parse callback URL: {e}"))?;
+
+        // Extract code and state from query params
+        let code = url
+            .query_pairs()
+            .find(|(k, _)| k == "code")
+            .map(|(_, v)| v.to_string())
+            .ok_or("no authorization code in callback")?;
+        let state = url
+            .query_pairs()
+            .find(|(k, _)| k == "state")
+            .map(|(_, v)| v.to_string())
+            .ok_or("no state in callback")?;
+
+        // Verify CSRF state
+        if state != *expected_state.secret() {
+            // Send error response before returning
+            let response = "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html\r\n\r\n<html><body><h1>Authentication Failed</h1><p>Invalid state parameter. Please try again.</p></body></html>";
+            let _ = stream.writable().await;
+            let _ = stream.try_write(response.as_bytes());
+            return Err("CSRF state mismatch — possible attack or stale callback".to_string());
+        }
+
+        // Send success response to the browser
+        let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n<html><body><h1>Authentication Successful</h1><p>You can close this tab and return to WackyTheorem.</p></body></html>";
+        let _ = stream.writable().await;
+        let _ = stream.try_write(response.as_bytes());
+
+        info!("received authorization code, exchanging for tokens");
+
+        // Exchange code for tokens
+        let client = build_oauth_client(&self.client_id)?
+            .set_redirect_uri(
+                RedirectUrl::new(format!("http://localhost:{}/callback", self.redirect_port))
+                    .map_err(|e| format!("invalid redirect URL: {e}"))?,
+            );
+        let http_client = reqwest::Client::new();
+
+        let token_result = client
+            .exchange_code(AuthorizationCode::new(code))
+            .set_pkce_verifier(verifier)
+            .request_async(&http_client)
+            .await
+            .map_err(|e| format!("token exchange failed: {e}"))?;
+
+        let expires_at = token_result
+            .expires_in()
+            .map(|d| chrono::Utc::now().timestamp() + d.as_secs() as i64);
+
+        Ok(StoredTokens {
+            access_token: token_result.access_token().secret().to_string(),
+            refresh_token: token_result
+                .refresh_token()
+                .map(|rt| rt.secret().to_string()),
+            expires_at,
+        })
+    }
+}
+
+/// Fully-configured OAuth2 client with auth + token endpoints set.
+type ConfiguredClient = BasicClient<EndpointSet, oauth2::EndpointNotSet, oauth2::EndpointNotSet, oauth2::EndpointNotSet, EndpointSet>;
+
+/// Build the shared OAuth2 client (no redirect URI — callers add their own).
+fn build_oauth_client(client_id: &str) -> Result<ConfiguredClient, String> {
+    Ok(BasicClient::new(ClientId::new(client_id.to_string()))
+        .set_auth_uri(
+            AuthUrl::new(GOOGLE_AUTH_URL.to_string())
+                .map_err(|e| format!("invalid auth URL: {e}"))?,
+        )
+        .set_token_uri(
+            TokenUrl::new(GOOGLE_TOKEN_URL.to_string())
+                .map_err(|e| format!("invalid token URL: {e}"))?,
+        ))
+}
+
+/// Find a free high port for the localhost redirect listener.
+pub async fn find_free_port() -> Result<u16, String> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| format!("failed to bind ephemeral port: {e}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("failed to get local address: {e}"))?
+        .port();
+    drop(listener);
+    Ok(port)
+}

--- a/crates/wkyt-connector-google/src/calendar.rs
+++ b/crates/wkyt-connector-google/src/calendar.rs
@@ -1,0 +1,421 @@
+//! Google Calendar API client.
+//!
+//! Fetches events from the user's primary calendar using the Calendar v3
+//! API. Supports both full sync (last 30+ days) and incremental sync via
+//! Google's `syncToken` / `nextPageToken` mechanism.
+//!
+//! The response `syncToken` maps directly to our [`SyncToken`]: Google
+//! hands us an opaque string that we persist in the vault and hand back
+//! on the next sync. If Google returns HTTP 410 GONE, the token is stale
+//! and we surface [`SyncError::ResyncRequired`].
+
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::{debug, warn};
+use wkyt_core::{Delta, DeltaBatch, Item, ItemKind, SyncError, SyncToken};
+
+const CALENDAR_API_BASE: &str = "https://www.googleapis.com/calendar/v3";
+/// Spec DoD #5: ≥30 days. We fetch 90 for comfort.
+const DEFAULT_LOOKBACK_DAYS: i64 = 90;
+const MAX_RESULTS_PER_PAGE: u32 = 250;
+
+/// One page of events from the Calendar API.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EventsListResponse {
+    items: Option<Vec<CalendarEvent>>,
+    next_page_token: Option<String>,
+    next_sync_token: Option<String>,
+}
+
+/// Minimal Calendar event structure — we extract what Phase 1 needs.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct CalendarEvent {
+    id: String,
+    status: Option<String>,
+    summary: Option<String>,
+    description: Option<String>,
+    location: Option<String>,
+    start: Option<EventDateTime>,
+    end: Option<EventDateTime>,
+    created: Option<String>,
+    updated: Option<String>,
+    organizer: Option<Organizer>,
+    html_link: Option<String>,
+    #[serde(default)]
+    attendees: Vec<Attendee>,
+    recurring_event_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct EventDateTime {
+    date_time: Option<String>,
+    date: Option<String>,
+    time_zone: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct Organizer {
+    email: Option<String>,
+    display_name: Option<String>,
+    #[serde(rename = "self")]
+    is_self: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct Attendee {
+    email: Option<String>,
+    display_name: Option<String>,
+    response_status: Option<String>,
+    #[serde(rename = "self")]
+    is_self: Option<bool>,
+}
+
+/// Opaque cursor we persist between syncs. Wraps either a Google
+/// `syncToken` (for incremental) or nothing (for full sync).
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct CalendarCursor {
+    /// Google's sync token for incremental sync.
+    sync_token: Option<String>,
+}
+
+/// Fetch all pages of calendar events and return them as delta batches.
+///
+/// This is called from the connector's `sync()` method. It handles:
+/// - Full sync: fetches events from `DEFAULT_LOOKBACK_DAYS` ago to now.
+/// - Incremental sync: uses Google's `syncToken` for efficient updates.
+/// - Pagination via `nextPageToken`.
+/// - HTTP 410 → `SyncError::ResyncRequired`.
+/// - HTTP 401/403 → `SyncError::AuthRequired`.
+pub async fn fetch_calendar_events(
+    http: &Client,
+    access_token: &str,
+    connector_id: &str,
+    cursor: Option<SyncToken>,
+    batch_size: usize,
+) -> Result<Vec<DeltaBatch>, SyncError> {
+    let prev_cursor: Option<CalendarCursor> = cursor
+        .as_ref()
+        .map(|c| serde_json::from_str(&c.0))
+        .transpose()
+        .map_err(|_| SyncError::ResyncRequired)?;
+
+    let google_sync_token = prev_cursor.as_ref().and_then(|c| c.sync_token.clone());
+    let is_incremental = google_sync_token.is_some();
+
+    let mut all_events: Vec<CalendarEvent> = Vec::new();
+    let mut page_token: Option<String> = None;
+    let mut final_sync_token: Option<String> = None;
+
+    loop {
+        let mut url = format!(
+            "{}/calendars/primary/events?maxResults={}&singleEvents=true&orderBy=startTime",
+            CALENDAR_API_BASE, MAX_RESULTS_PER_PAGE
+        );
+
+        if let Some(ref sync_tok) = google_sync_token {
+            // Incremental sync — Google ignores timeMin/timeMax/orderBy when
+            // syncToken is provided, so we don't add them.
+            if page_token.is_none() {
+                url = format!(
+                    "{}/calendars/primary/events?maxResults={}&syncToken={}",
+                    CALENDAR_API_BASE,
+                    MAX_RESULTS_PER_PAGE,
+                    urlencoding::encode(sync_tok)
+                );
+            }
+        } else {
+            // Full sync — look back DEFAULT_LOOKBACK_DAYS.
+            let time_min = (Utc::now() - chrono::Duration::days(DEFAULT_LOOKBACK_DAYS))
+                .to_rfc3339();
+            url.push_str(&format!("&timeMin={}", urlencoding::encode(&time_min)));
+        }
+
+        if let Some(ref pt) = page_token {
+            url.push_str(&format!("&pageToken={}", urlencoding::encode(pt)));
+        }
+
+        debug!(url = %url, incremental = is_incremental, "fetching calendar events page");
+
+        let response = http
+            .get(&url)
+            .bearer_auth(access_token)
+            .send()
+            .await
+            .map_err(|e| SyncError::Retryable {
+                source: Box::new(e),
+                retry_after: None,
+            })?;
+
+        let status = response.status();
+        if status == reqwest::StatusCode::GONE {
+            // 410: sync token expired. Discard and full-resync.
+            warn!("Google Calendar returned 410 GONE — sync token expired");
+            return Err(SyncError::ResyncRequired);
+        }
+        if status == reqwest::StatusCode::UNAUTHORIZED
+            || status == reqwest::StatusCode::FORBIDDEN
+        {
+            return Err(SyncError::AuthRequired {
+                reason: format!("Google Calendar API returned {status}"),
+            });
+        }
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(SyncError::Retryable {
+                source: format!("Google Calendar API error {status}: {body}").into(),
+                retry_after: None,
+            });
+        }
+
+        let page: EventsListResponse =
+            response.json().await.map_err(|e| SyncError::Retryable {
+                source: Box::new(e),
+                retry_after: None,
+            })?;
+
+        if let Some(events) = page.items {
+            all_events.extend(events);
+        }
+
+        if let Some(nst) = page.next_sync_token {
+            final_sync_token = Some(nst);
+        }
+
+        match page.next_page_token {
+            Some(npt) => page_token = Some(npt),
+            None => break,
+        }
+    }
+
+    debug!(
+        event_count = all_events.len(),
+        incremental = is_incremental,
+        "calendar events fetched"
+    );
+
+    // Convert to delta batches
+    let cursor_value = CalendarCursor {
+        sync_token: final_sync_token,
+    };
+    let cursor_token = SyncToken(
+        serde_json::to_string(&cursor_value).expect("cursor serialization is infallible"),
+    );
+
+    let mut batches = Vec::new();
+    for chunk in all_events.chunks(batch_size).collect::<Vec<_>>().into_iter() {
+        let deltas: Vec<Delta> = chunk
+            .iter()
+            .map(|event| event_to_delta(connector_id, event))
+            .collect();
+        batches.push(DeltaBatch {
+            connector_id: connector_id.to_string(),
+            deltas,
+            cursor: None, // intermediate batches don't carry a cursor
+        });
+    }
+
+    // Last batch (or a synthetic empty one) carries the cursor.
+    if let Some(last) = batches.last_mut() {
+        last.cursor = Some(cursor_token);
+    } else {
+        // No events at all — still need to persist the sync token.
+        batches.push(DeltaBatch {
+            connector_id: connector_id.to_string(),
+            deltas: Vec::new(),
+            cursor: Some(cursor_token),
+        });
+    }
+
+    Ok(batches)
+}
+
+/// Convert a single Calendar event to a Delta.
+fn event_to_delta(connector_id: &str, event: &CalendarEvent) -> Delta {
+    // Cancelled events are tombstones.
+    if event.status.as_deref() == Some("cancelled") {
+        return Delta::Tombstone {
+            source_id: event.id.clone(),
+        };
+    }
+
+    let timestamp = parse_event_start(event)
+        .unwrap_or_else(Utc::now); // fallback shouldn't happen for valid events
+
+    let properties = json!({
+        "summary": event.summary,
+        "description": event.description,
+        "location": event.location,
+        "start": event.start.as_ref().map(|s| json!({
+            "dateTime": s.date_time,
+            "date": s.date,
+            "timeZone": s.time_zone,
+        })),
+        "end": event.end.as_ref().map(|e| json!({
+            "dateTime": e.date_time,
+            "date": e.date,
+            "timeZone": e.time_zone,
+        })),
+        "organizer": event.organizer.as_ref().map(|o| json!({
+            "email": o.email,
+            "displayName": o.display_name,
+            "self": o.is_self,
+        })),
+        "htmlLink": event.html_link,
+        "attendees": event.attendees.iter().map(|a| json!({
+            "email": a.email,
+            "displayName": a.display_name,
+            "responseStatus": a.response_status,
+            "self": a.is_self,
+        })).collect::<Vec<_>>(),
+        "recurringEventId": event.recurring_event_id,
+        "created": event.created,
+        "updated": event.updated,
+    });
+
+    let mut item = Item::new(
+        &event.id,
+        connector_id,
+        ItemKind::Event,
+        timestamp,
+        properties,
+    );
+
+    // Stash the raw Google response for traceability.
+    item.raw_payload = serde_json::to_value(event).ok();
+
+    Delta::Upsert(item)
+}
+
+/// Parse the event's start time. Prefer `dateTime`; fall back to `date`
+/// (all-day events use date-only format).
+fn parse_event_start(event: &CalendarEvent) -> Option<DateTime<Utc>> {
+    let start = event.start.as_ref()?;
+    if let Some(ref dt) = start.date_time {
+        return DateTime::parse_from_rfc3339(dt)
+            .ok()
+            .map(|d| d.with_timezone(&Utc));
+    }
+    if let Some(ref d) = start.date {
+        // All-day event: "2025-07-04". Parse as midnight UTC.
+        return chrono::NaiveDate::parse_from_str(d, "%Y-%m-%d")
+            .ok()
+            .and_then(|nd| nd.and_hms_opt(0, 0, 0))
+            .map(|ndt| DateTime::<Utc>::from_naive_utc_and_offset(ndt, Utc));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Timelike;
+
+    #[test]
+    fn cancelled_event_becomes_tombstone() {
+        let event = CalendarEvent {
+            id: "evt-1".into(),
+            status: Some("cancelled".into()),
+            summary: None,
+            description: None,
+            location: None,
+            start: None,
+            end: None,
+            created: None,
+            updated: None,
+            organizer: None,
+            html_link: None,
+            attendees: Vec::new(),
+            recurring_event_id: None,
+        };
+        match event_to_delta("google-calendar", &event) {
+            Delta::Tombstone { source_id } => assert_eq!(source_id, "evt-1"),
+            other => panic!("expected Tombstone, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn datetime_event_uses_start_time() {
+        let event = CalendarEvent {
+            id: "evt-2".into(),
+            status: Some("confirmed".into()),
+            summary: Some("Standup".into()),
+            description: None,
+            location: None,
+            start: Some(EventDateTime {
+                date_time: Some("2025-07-04T09:00:00-05:00".into()),
+                date: None,
+                time_zone: Some("America/Chicago".into()),
+            }),
+            end: Some(EventDateTime {
+                date_time: Some("2025-07-04T09:30:00-05:00".into()),
+                date: None,
+                time_zone: Some("America/Chicago".into()),
+            }),
+            created: None,
+            updated: None,
+            organizer: None,
+            html_link: None,
+            attendees: Vec::new(),
+            recurring_event_id: None,
+        };
+
+        match event_to_delta("google-calendar", &event) {
+            Delta::Upsert(item) => {
+                assert_eq!(item.source_id, "evt-2");
+                assert_eq!(item.kind, ItemKind::Event);
+                // 09:00 CDT = 14:00 UTC
+                assert_eq!(item.timestamp.hour(), 14);
+                assert_eq!(item.properties["summary"], "Standup");
+            }
+            other => panic!("expected Upsert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn allday_event_parses_date_only() {
+        let event = CalendarEvent {
+            id: "evt-3".into(),
+            status: Some("confirmed".into()),
+            summary: Some("Independence Day".into()),
+            description: None,
+            location: None,
+            start: Some(EventDateTime {
+                date_time: None,
+                date: Some("2025-07-04".into()),
+                time_zone: None,
+            }),
+            end: Some(EventDateTime {
+                date_time: None,
+                date: Some("2025-07-05".into()),
+                time_zone: None,
+            }),
+            created: None,
+            updated: None,
+            organizer: None,
+            html_link: None,
+            attendees: Vec::new(),
+            recurring_event_id: None,
+        };
+
+        match event_to_delta("google-calendar", &event) {
+            Delta::Upsert(item) => {
+                assert_eq!(item.timestamp.date_naive().to_string(), "2025-07-04");
+            }
+            other => panic!("expected Upsert, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deterministic_id_is_stable() {
+        // Pin the expected ID so connector_id changes don't go unnoticed.
+        let id = Item::deterministic_id("google-calendar", "evt-1");
+        assert_eq!(id.to_string(), "3aaae9bc-36b9-540b-9158-3537f91fe703");
+    }
+}

--- a/crates/wkyt-connector-google/src/lib.rs
+++ b/crates/wkyt-connector-google/src/lib.rs
@@ -1,0 +1,136 @@
+//! Google Calendar connector (D3–D6).
+//!
+//! Implements the [`Connector`] trait for Google Calendar events. The auth
+//! flow (OAuth 2.0 PKCE) is decoupled: if no valid tokens exist, `sync()`
+//! returns [`SyncError::AuthRequired`] and the orchestrator/UI is
+//! responsible for triggering the PKCE flow via [`auth::PkceFlow`] and
+//! persisting tokens via [`auth::TokenStore`].
+//!
+//! # Architecture
+//!
+//! ```text
+//!                         ┌──────────────────────────┐
+//!   Tauri UI              │   GoogleCalendarConnector │
+//!   ───────►  auth::      │                          │
+//!             PkceFlow    │  sync(cursor)            │
+//!             ──────►     │    ├─ token_store.access_token()
+//!             TokenStore  │    │   └─ keyring or refresh
+//!                         │    └─ calendar::fetch_calendar_events()
+//!                         │        └─ reqwest → Calendar API v3
+//!                         └──────────────────────────┘
+//! ```
+
+pub mod auth;
+pub mod calendar;
+
+use auth::TokenStore;
+use futures_util::{stream, StreamExt as _};
+use std::sync::Arc;
+use wkyt_core::{Connector, DeltaStream, SyncError, SyncToken};
+
+const CONNECTOR_ID: &str = "google-calendar";
+const DEFAULT_BATCH_SIZE: usize = 100;
+
+/// Google Calendar connector. Holds shared state (token store, HTTP client)
+/// and exposes the standard [`Connector`] interface.
+pub struct GoogleCalendarConnector {
+    token_store: Arc<TokenStore>,
+    http: reqwest::Client,
+    batch_size: usize,
+}
+
+impl GoogleCalendarConnector {
+    /// Create a new connector.
+    ///
+    /// `client_id` is the Google OAuth client ID (from Google Cloud Console).
+    /// It is NOT a secret — PKCE replaces the client secret.
+    pub fn new(client_id: impl Into<String>) -> Self {
+        Self {
+            token_store: Arc::new(TokenStore::new(client_id)),
+            http: reqwest::Client::new(),
+            batch_size: DEFAULT_BATCH_SIZE,
+        }
+    }
+
+    /// Access the token store for auth flow operations.
+    pub fn token_store(&self) -> &Arc<TokenStore> {
+        &self.token_store
+    }
+}
+
+#[async_trait::async_trait]
+impl Connector for GoogleCalendarConnector {
+    fn id(&self) -> &str {
+        CONNECTOR_ID
+    }
+
+    /// Load cached tokens from the OS keychain. Cheap if already loaded.
+    async fn init(&self) -> Result<(), SyncError> {
+        // spawn_blocking because keyring ops are synchronous
+        let store = self.token_store.clone();
+        tokio::task::spawn_blocking(move || store.load_from_keyring())
+            .await
+            .map_err(|e| SyncError::Fatal {
+                source: format!("join error: {e}").into(),
+            })?
+            .map_err(|e| SyncError::Fatal {
+                source: e.into(),
+            })?;
+        Ok(())
+    }
+
+    /// Stream calendar event batches.
+    ///
+    /// If no valid access token is available, yields a single
+    /// `AuthRequired` error — the orchestrator should pause this connector
+    /// and surface the auth UI.
+    fn sync(&self, cursor: Option<SyncToken>) -> DeltaStream<'_> {
+        let http = self.http.clone();
+        let token_store = self.token_store.clone();
+        let connector_id = CONNECTOR_ID.to_string();
+        let batch_size = self.batch_size;
+
+        Box::pin(stream::once(async move {
+            // Get a valid access token (may silently refresh).
+            let access_token = token_store
+                .access_token()
+                .await
+                .map_err(|e| SyncError::Fatal { source: e.into() })?
+                .ok_or_else(|| SyncError::AuthRequired {
+                    reason: "no Google OAuth tokens — user must authenticate".into(),
+                })?;
+
+            // Fetch all pages from Google and return batches.
+            let batches = calendar::fetch_calendar_events(
+                &http,
+                &access_token,
+                &connector_id,
+                cursor,
+                batch_size,
+            )
+            .await?;
+
+            Ok(batches)
+        })
+        // flatten: the single future returns Vec<DeltaBatch>, we need to
+        // stream each batch individually.
+        .flat_map(|result| match result {
+            Ok(batches) => {
+                let items: Vec<Result<_, SyncError>> = batches.into_iter().map(Ok).collect();
+                stream::iter(items).left_stream()
+            }
+            Err(e) => stream::iter(vec![Err(e)]).right_stream(),
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connector_id_matches_item_test_expectations() {
+        let c = GoogleCalendarConnector::new("test-client-id");
+        assert_eq!(c.id(), "google-calendar");
+    }
+}

--- a/deleteme.md
+++ b/deleteme.md
@@ -1,3 +1,0 @@
-# Delete Me
-
-This file was created as a test. Feel free to delete it.

--- a/desktop/wkyt/src-tauri/Cargo.toml
+++ b/desktop/wkyt/src-tauri/Cargo.toml
@@ -32,6 +32,10 @@ wkyt-vault = { workspace = true }
 wkyt-host = { workspace = true }
 # The M4 file-importer connector driven by the debug pipeline.
 wkyt-connector-file = { workspace = true }
+# Google Calendar connector: OAuth PKCE + Calendar API ingestion (D3-D6).
+wkyt-connector-google = { workspace = true }
+# Open the user's default browser for OAuth redirect.
+open = "5"
 # Polling interval for the debug import-folder watcher.
 tokio = { workspace = true, features = ["time"] }
 # Event timestamps when constructing items (e.g. MockConnector).
@@ -40,3 +44,5 @@ chrono = { workspace = true }
 async-trait = { workspace = true }
 # StreamExt to drain connector delta streams in the setup task.
 futures-util = { workspace = true }
+# Tracing diagnostics for auth flow.
+tracing = "0.1"

--- a/desktop/wkyt/src-tauri/src/google_auth.rs
+++ b/desktop/wkyt/src-tauri/src/google_auth.rs
@@ -1,114 +1,139 @@
-use serde::{Deserialize, Serialize};
-// Emitter is only used by the debug-mode mock flows below; gating the
-// import keeps release builds warning-free.
-#[cfg(debug_assertions)]
-use tauri::Emitter;
-use tauri::Window;
+//! Google OAuth 2.0 PKCE commands (D3/D5).
+//!
+//! The real flow:
+//! 1. Frontend calls `start_oauth` → spawns PKCE flow, opens browser.
+//! 2. User consents → localhost callback → tokens exchanged and stored.
+//! 3. Frontend calls `google_auth_status` to check if tokens exist.
+//! 4. On vault READY, the Google Calendar connector joins the pipeline.
+//!
+//! Client ID is read from the `WKYT_GOOGLE_CLIENT_ID` env var at runtime.
+//! It is NOT a secret (Google's installed-app docs explicitly say this),
+//! but we don't compile it into the binary so users can bring their own
+//! Google Cloud project.
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct GoogleUser {
-    pub email: String,
-    pub name: String,
-    pub picture: Option<String>,
-}
+use serde::Serialize;
+use std::sync::Arc;
+use wkyt_connector_google::auth;
 
+/// OAuth status returned to the frontend.
 #[derive(Debug, Serialize, Clone)]
-pub struct OAuthCodePayload {
-    pub code: String,
-    pub state: String,
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum GoogleAuthStatus {
+    /// No client ID configured — Google features disabled.
+    NotConfigured,
+    /// Client ID present but no tokens — user needs to authenticate.
+    NeedsAuth,
+    /// Tokens present and (possibly) valid.
+    Authenticated { email: Option<String> },
 }
 
-// Basic auth state holder (placeholder for real OAuth flow)
-pub struct AuthState {
-    pub current_user: Option<GoogleUser>,
+/// Shared state for Google auth, managed alongside AppState.
+pub struct GoogleAuthState {
+    client_id: Option<String>,
+    token_store: Option<Arc<auth::TokenStore>>,
 }
 
-impl AuthState {
+impl GoogleAuthState {
     pub fn new() -> Self {
-        Self { current_user: None }
+        let client_id = std::env::var("WKYT_GOOGLE_CLIENT_ID").ok();
+        let token_store = client_id
+            .as_ref()
+            .map(|id| Arc::new(auth::TokenStore::new(id.clone())));
+
+        Self {
+            client_id,
+            token_store,
+        }
+    }
+
+    pub fn client_id(&self) -> Option<&str> {
+        self.client_id.as_deref()
+    }
+
+    pub fn token_store(&self) -> Option<&Arc<auth::TokenStore>> {
+        self.token_store.as_ref()
     }
 }
 
+/// Check the current Google auth status.
 #[tauri::command]
-pub fn start_oauth(window: Window, state: String) -> Result<(), String> {
-    #[cfg(debug_assertions)]
-    {
-        // This is where we would trigger the OIDC flow
-        // For now, we just emit a mock oauth-code event
-        let _ = window.emit(
-            "oauth-code",
-            OAuthCodePayload {
-                code: "mock-code-123".to_string(),
-                state,
-            },
-        );
-        Ok(())
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        let _ = window;
-        let _ = state;
-        // In production, real OAuth flow must be implemented.
-        Err("OAuth flow is not implemented for production builds yet.".to_string())
-    }
-}
-
-#[tauri::command]
-pub fn logout() {
-    println!("Logging out");
-}
-
-#[tauri::command]
-pub fn exchange_code_for_token(code: String) -> Result<String, String> {
-    #[cfg(debug_assertions)]
-    {
-        Ok(format!("mock-token-for-{}", code))
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        let _ = code;
-        // In production, real token exchange must be implemented.
-        Err("Token exchange is not implemented for production builds yet.".to_string())
-    }
-}
-
-#[tauri::command]
-pub fn get_user_info(token: String) -> Result<GoogleUser, String> {
-    #[cfg(debug_assertions)]
-    {
-        // In debug mode, return mock user data
-        println!("Getting user info for token: {}", token);
-        Ok(GoogleUser {
-            email: "test@example.com".to_string(),
-            name: "Test User".to_string(),
-            picture: None,
-        })
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        let _ = token;
-        // In production, we must not return hardcoded mock data.
-        // Real implementation of token verification and user info fetching is required.
-        Err("Google user info fetching is not implemented for production builds yet.".to_string())
-    }
-}
-
-pub fn initiate_auth(window: &Window) {
-    #[cfg(debug_assertions)]
-    {
-        // This is where we would trigger the OIDC flow
-        // For now, we just emit a mock success event
-        let mock_user = GoogleUser {
-            email: "demo@wkyt.app".to_string(),
-            name: "Demo User".to_string(),
-            picture: None,
+pub async fn google_auth_status(
+    state: tauri::State<'_, Arc<GoogleAuthState>>,
+) -> Result<GoogleAuthStatus, String> {
+    let s = Arc::clone(&state);
+    tauri::async_runtime::spawn_blocking(move || {
+        let Some(store) = s.token_store() else {
+            return Ok(GoogleAuthStatus::NotConfigured);
         };
 
-        let _ = window.emit("auth-success", mock_user);
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        let _ = window;
-        // In production, real auth initiation must be implemented.
-    }
+        match store.load_from_keyring() {
+            Ok(true) => Ok(GoogleAuthStatus::Authenticated { email: None }),
+            Ok(false) => Ok(GoogleAuthStatus::NeedsAuth),
+            Err(e) => {
+                eprintln!("[wkyt] keyring read warning: {e}");
+                Ok(GoogleAuthStatus::NeedsAuth)
+            }
+        }
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Start the OAuth PKCE flow: find a free port, generate the auth URL,
+/// open the browser, wait for the callback, exchange the code, store tokens.
+///
+/// This is a long-running command — the frontend should show a spinner
+/// while waiting.
+#[tauri::command]
+pub async fn start_oauth(
+    state: tauri::State<'_, Arc<GoogleAuthState>>,
+) -> Result<GoogleAuthStatus, String> {
+    let client_id = state
+        .client_id()
+        .ok_or("WKYT_GOOGLE_CLIENT_ID is not set")?
+        .to_string();
+
+    let store = state
+        .token_store()
+        .ok_or("Google auth not configured")?
+        .clone();
+
+    // Find a free port for the redirect listener
+    let port = auth::find_free_port()
+        .await
+        .map_err(|e| format!("port allocation failed: {e}"))?;
+
+    // Set up the PKCE flow
+    let mut flow = auth::PkceFlow::new(&client_id, port);
+    let auth_url = flow.authorize_url()
+        .map_err(|e| format!("failed to generate auth URL: {e}"))?;
+
+    // Open the browser
+    open::that(&auth_url).map_err(|e| format!("failed to open browser: {e}"))?;
+
+    // Wait for callback and exchange (this blocks until the user completes consent)
+    let tokens = flow
+        .wait_for_callback_and_exchange()
+        .await
+        .map_err(|e| format!("OAuth flow failed: {e}"))?;
+
+    // Store tokens in keyring
+    store
+        .store(tokens)
+        .await
+        .map_err(|e| format!("failed to store tokens: {e}"))?;
+
+    Ok(GoogleAuthStatus::Authenticated { email: None })
+}
+
+/// Clear stored Google tokens (logout).
+#[tauri::command]
+pub async fn google_logout(
+    state: tauri::State<'_, Arc<GoogleAuthState>>,
+) -> Result<(), String> {
+    let store = state
+        .token_store()
+        .ok_or("Google auth not configured")?
+        .clone();
+    store.clear().await
 }

--- a/desktop/wkyt/src-tauri/src/lib.rs
+++ b/desktop/wkyt/src-tauri/src/lib.rs
@@ -20,6 +20,11 @@ pub fn run() {
             // is driven by the frontend through vault_commands; nothing is
             // unlocked and no ingestion runs until the UI asks.
             app.manage(Arc::new(AppState::new(app_data_dir)));
+
+            // Google auth state: reads WKYT_GOOGLE_CLIENT_ID from env.
+            // If unset, Google features are disabled gracefully.
+            app.manage(Arc::new(google_auth::GoogleAuthState::new()));
+
             Ok(())
         })
         .plugin(tauri_plugin_opener::init())
@@ -30,10 +35,9 @@ pub fn run() {
             vault_commands::recover_with_key,
             vault_commands::get_items,
             vault_commands::get_stats,
+            google_auth::google_auth_status,
             google_auth::start_oauth,
-            google_auth::logout,
-            google_auth::exchange_code_for_token,
-            google_auth::get_user_info
+            google_auth::google_logout,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/desktop/wkyt/src-tauri/src/vault_commands.rs
+++ b/desktop/wkyt/src-tauri/src/vault_commands.rs
@@ -25,6 +25,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use wkyt_connector_file::FileImporter;
+use wkyt_connector_google::GoogleCalendarConnector;
 use wkyt_vault::{unlock_vault, KeyError, KeyService, KeyState, KeyringStore, Vault};
 
 const KEYRING_SERVICE: &str = "wkyt";
@@ -115,21 +116,56 @@ fn start_pipeline(app: &tauri::AppHandle, state: &AppState) {
     let connector = FileImporter::new("file-import", state.import_dir.clone());
     println!("[wkyt] watching {:?} — drop .json/.ics files there", state.import_dir);
     let _app = app.clone(); // reserved for emitting ingest events to the UI later
+
+    // File importer loop (existing)
+    let vault_file = Arc::clone(&vault);
     tauri::async_runtime::spawn(async move {
         loop {
-            match wkyt_host::run_pipeline_once(&connector, Arc::clone(&vault)).await {
+            match wkyt_host::run_pipeline_once(&connector, Arc::clone(&vault_file)).await {
                 Ok(stats) if stats.batches_applied > 0 => {
                     println!(
-                        "[wkyt] ingested {} deltas in {} batches",
+                        "[wkyt] file: ingested {} deltas in {} batches",
                         stats.deltas_applied, stats.batches_applied
                     );
                 }
                 Ok(_) => {}
-                Err(e) => eprintln!("[wkyt] pipeline pass failed: {e}"),
+                Err(e) => eprintln!("[wkyt] file pipeline pass failed: {e}"),
             }
             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
         }
     });
+
+    // Google Calendar connector loop (only if client_id is configured)
+    if let Ok(client_id) = std::env::var("WKYT_GOOGLE_CLIENT_ID") {
+        let vault_google = Arc::clone(&vault);
+        let google = GoogleCalendarConnector::new(client_id);
+        tauri::async_runtime::spawn(async move {
+            // Initial delay: let the file pipeline settle first.
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            loop {
+                match wkyt_host::run_pipeline_once(&google, Arc::clone(&vault_google)).await {
+                    Ok(stats) if stats.batches_applied > 0 => {
+                        println!(
+                            "[wkyt] google: ingested {} deltas in {} batches",
+                            stats.deltas_applied, stats.batches_applied
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        // AuthRequired is expected before the user logs in;
+                        // don't spam the console.
+                        let msg = e.to_string();
+                        if !msg.contains("AuthRequired") && !msg.contains("authentication") {
+                            eprintln!("[wkyt] google pipeline pass failed: {e}");
+                        }
+                    }
+                }
+                // Poll less frequently than the file importer: calendar
+                // data changes slowly and we don't want to burn API quota.
+                tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+            }
+        });
+    }
 }
 
 #[tauri::command]


### PR DESCRIPTION
## What

New crate `wkyt-connector-google` implementing Google OAuth 2.0 PKCE flow and Calendar API v3 ingestion, wired into the Tauri app.

### `wkyt-connector-google` crate
- **auth.rs** — OAuth 2.0 PKCE with localhost redirect (D5), token refresh, keyring persistence via `TokenStore` (D3)
- **calendar.rs** — Google Calendar API v3: pagination, full sync (90-day lookback) + incremental via Google `syncToken`, cancelled events → tombstones, all-day + timed event parsing
- **lib.rs** — `GoogleCalendarConnector` implementing the `Connector` trait; returns `AuthRequired` when no tokens exist

### Tauri app integration
- **google_auth.rs** — real PKCE commands replacing debug mocks (`start_oauth`, `google_auth_status`, `google_logout`)
- **vault_commands.rs** — Google Calendar connector joins the pipeline loop (5-min poll) when `WKYT_GOOGLE_CLIENT_ID` env var is set
- **lib.rs** — registers `GoogleAuthState` and new command handlers

### Design decisions
- Client ID via `WKYT_GOOGLE_CLIENT_ID` env var (not compiled in; users bring their own Google Cloud project)
- `oauth2` v5 crate with `reqwest` for HTTP (D5/D6)
- Tokens in OS keychain via `keyring` (D3)
- 67 tests pass across the full workspace

## Still needed (follow-up PRs)
- Svelte frontend updates to call the new commands
- Headless-Linux keyring fallback (Argon2id)